### PR TITLE
fix: resolve .cursor install path correctly on WSL

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -187,6 +187,26 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, useSlashSyntax) {
   }
 }
 
+
+/**
+ * On WSL, Cursor runs on Windows — must write to Windows .cursor dir,
+ * not the WSL home directory which Cursor cannot see.
+ */
+function resolveWSLCursorHome() {
+  try {
+    const isWSL = process.platform === 'linux' &&
+      fs.existsSync('/proc/version') &&
+      fs.readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
+    const winProfile = require('child_process')
+      .execSync('cmd.exe /c "echo %USERPROFILE%"', { encoding: 'utf8' })
+      .trim()
+      .replace(/\r/g, '')
+      .replace(/^C:\\/, '/mnt/c/')
+      .replace(/\\/g, '/');
+    return winProfile + '/.cursor';
+  } catch { return null; }
+}
+
 /**
  * Install to the specified directory
  */
@@ -217,7 +237,8 @@ function install(isGlobal) {
   if (isAntigravity) {
     targetDir = path.join(process.cwd(), '.agent');
   } else {
-    const defaultGlobalDir = configDir || path.join(os.homedir(), defaultDirName);
+    const wslCursorHome = isCursor ? resolveWSLCursorHome() : null;
+    const defaultGlobalDir = configDir || wslCursorHome || path.join(os.homedir(), defaultDirName);
     targetDir = isGlobal
       ? defaultGlobalDir
       : path.join(process.cwd(), defaultDirName);

--- a/cursor-rules/gsd-add-phase.mdc
+++ b/cursor-rules/gsd-add-phase.mdc
@@ -1,0 +1,205 @@
+---
+description: "When user types /gsd/add-phase - Add phase to end of current milestone in roadmap"
+globs:
+alwaysApply: false
+---
+
+# /gsd/add-phase
+
+<objective>
+Add a new integer phase to the end of the current milestone in the roadmap.
+
+This command appends sequential phases to the current milestone's phase list, automatically calculating the next phase number based on existing phases.
+
+Purpose: Add planned work discovered during execution that belongs at the end of current milestone.
+</objective>
+
+<execution_context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</execution_context>
+
+<process>
+
+<step name="parse_arguments">
+Parse the command arguments:
+- All arguments become the phase description
+- Example: `/gsd/add-phase Add authentication` → description = "Add authentication"
+- Example: `/gsd/add-phase Fix critical performance issues` → description = "Fix critical performance issues"
+
+If no arguments provided:
+
+```
+ERROR: Phase description required
+Usage: /gsd/add-phase <description>
+Example: /gsd/add-phase Add authentication system
+```
+
+Exit.
+</step>
+
+<step name="load_roadmap">
+Load the roadmap file:
+
+```bash
+if [ -f .planning/ROADMAP.md ]; then
+  ROADMAP=".planning/ROADMAP.md"
+else
+  echo "ERROR: No roadmap found (.planning/ROADMAP.md)"
+  exit 1
+fi
+```
+
+Read roadmap content for parsing.
+</step>
+
+<step name="find_current_milestone">
+Parse the roadmap to find the current milestone section:
+
+1. Locate the "## Current Milestone:" heading
+2. Extract milestone name and version
+3. Identify all phases under this milestone (before next "---" separator or next milestone heading)
+4. Parse existing phase numbers (including decimals if present)
+
+Example structure:
+
+```
+## Current Milestone: v1.0 Foundation
+
+### Phase 4: Focused Command System
+### Phase 5: Path Routing & Validation
+### Phase 6: Documentation & Distribution
+```
+
+</step>
+
+<step name="calculate_next_phase">
+Find the highest integer phase number in the current milestone:
+
+1. Extract all phase numbers from phase headings (### Phase N:)
+2. Filter to integer phases only (ignore decimals like 4.1, 4.2)
+3. Find the maximum integer value
+4. Add 1 to get the next phase number
+
+Example: If phases are 4, 5, 5.1, 6 → next is 7
+
+Format as two-digit: `printf "%02d" $next_phase`
+</step>
+
+<step name="generate_slug">
+Convert the phase description to a kebab-case slug:
+
+```bash
+# Example transformation:
+# "Add authentication" → "add-authentication"
+# "Fix critical performance issues" → "fix-critical-performance-issues"
+
+slug=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+```
+
+Phase directory name: `{two-digit-phase}-{slug}`
+Example: `07-add-authentication`
+</step>
+
+<step name="create_phase_directory">
+Create the phase directory structure:
+
+```bash
+phase_dir=".planning/phases/${phase_num}-${slug}"
+mkdir -p "$phase_dir"
+```
+
+Confirm: "Created directory: $phase_dir"
+</step>
+
+<step name="update_roadmap">
+Add the new phase entry to the roadmap:
+
+1. Find the insertion point (after last phase in current milestone, before "---" separator)
+2. Insert new phase heading:
+
+   ```
+   ### Phase {N}: {Description}
+
+   **Goal:** [To be planned]
+   **Depends on:** Phase {N-1}
+   **Plans:** 0 plans
+
+   Plans:
+   - [ ] TBD (run /gsd/plan-phase {N} to break down)
+
+   **Details:**
+   [To be added during planning]
+   ```
+
+3. Write updated roadmap back to file
+
+Preserve all other content exactly (formatting, spacing, other phases).
+</step>
+
+<step name="update_project_state">
+Update STATE.md to reflect the new phase:
+
+1. Read `.planning/STATE.md`
+2. Under "## Current Position" → "**Next Phase:**" add reference to new phase
+3. Under "## Accumulated Context" → "### Roadmap Evolution" add entry:
+   ```
+   - Phase {N} added: {description}
+   ```
+
+If "Roadmap Evolution" section doesn't exist, create it.
+</step>
+
+<step name="completion">
+Present completion summary:
+
+```
+Phase {N} added to current milestone:
+- Description: {description}
+- Directory: .planning/phases/{phase-num}-{slug}/
+- Status: Not planned yet
+
+Roadmap updated: {roadmap-path}
+Project state updated: .planning/STATE.md
+
+---
+
+## ▶ Next Up
+
+**Phase {N}: {description}**
+
+`/gsd/plan-phase {N}`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `/gsd/add-phase <description>` — add another phase
+- Review roadmap
+
+---
+```
+</step>
+
+</process>
+
+<anti_patterns>
+
+- Don't modify phases outside current milestone
+- Don't renumber existing phases
+- Don't use decimal numbering (that's /gsd/insert-phase)
+- Don't create plans yet (that's /gsd/plan-phase)
+- Don't commit changes (user decides when to commit)
+  </anti_patterns>
+
+<success_criteria>
+Phase addition is complete when:
+
+- [ ] Phase directory created: `.planning/phases/{NN}-{slug}/`
+- [ ] Roadmap updated with new phase entry
+- [ ] STATE.md updated with roadmap evolution note
+- [ ] New phase appears at end of current milestone
+- [ ] Next phase number calculated correctly (ignoring decimals)
+- [ ] User informed of next steps
+      </success_criteria>

--- a/cursor-rules/gsd-add-todo.mdc
+++ b/cursor-rules/gsd-add-todo.mdc
@@ -1,0 +1,179 @@
+---
+description: "When user types /gsd/add-todo - Capture idea or task as todo from current conversation context"
+globs:
+alwaysApply: false
+---
+
+# /gsd/add-todo
+
+<objective>
+Capture an idea, task, or issue that surfaces during a GSD session as a structured todo for later work.
+
+Enables "thought → capture → continue" flow without losing context or derailing current work.
+</objective>
+
+<context>
+@.planning/STATE.md
+</context>
+
+<process>
+
+<step name="ensure_directory">
+```bash
+mkdir -p .planning/todos/pending .planning/todos/done
+```
+</step>
+
+<step name="check_existing_areas">
+```bash
+ls .planning/todos/pending/*.md 2>/dev/null | xargs -I {} grep "^area:" {} 2>/dev/null | cut -d' ' -f2 | sort -u
+```
+
+Note existing areas for consistency in infer_area step.
+</step>
+
+<step name="extract_content">
+**With arguments:** Use as the title/focus.
+- `/gsd/add-todo Add auth token refresh` → title = "Add auth token refresh"
+
+**Without arguments:** Analyze recent conversation to extract:
+- The specific problem, idea, or task discussed
+- Relevant file paths mentioned
+- Technical details (error messages, line numbers, constraints)
+
+Formulate:
+- `title`: 3-10 word descriptive title (action verb preferred)
+- `problem`: What's wrong or why this is needed
+- `solution`: Approach hints or "TBD" if just an idea
+- `files`: Relevant paths with line numbers from conversation
+</step>
+
+<step name="infer_area">
+Infer area from file paths:
+
+| Path pattern | Area |
+|--------------|------|
+| `src/api/*`, `api/*` | `api` |
+| `src/components/*`, `src/ui/*` | `ui` |
+| `src/auth/*`, `auth/*` | `auth` |
+| `src/db/*`, `database/*` | `database` |
+| `tests/*`, `__tests__/*` | `testing` |
+| `docs/*` | `docs` |
+| `.planning/*` | `planning` |
+| `scripts/*`, `bin/*` | `tooling` |
+| No files or unclear | `general` |
+
+Use existing area from step 2 if similar match exists.
+</step>
+
+<step name="check_duplicates">
+```bash
+grep -l -i "[key words from title]" .planning/todos/pending/*.md 2>/dev/null
+```
+
+If potential duplicate found:
+1. Read the existing todo
+2. Compare scope
+
+If overlapping, use AskUserQuestion:
+- header: "Duplicate?"
+- question: "Similar todo exists: [title]. What would you like to do?"
+- options:
+  - "Skip" — keep existing todo
+  - "Replace" — update existing with new context
+  - "Add anyway" — create as separate todo
+</step>
+
+<step name="create_file">
+```bash
+timestamp=$(date "+%Y-%m-%dT%H:%M")
+date_prefix=$(date "+%Y-%m-%d")
+```
+
+Generate slug from title (lowercase, hyphens, no special chars).
+
+Write to `.planning/todos/pending/${date_prefix}-${slug}.md`:
+
+```markdown
+---
+created: [timestamp]
+title: [title]
+area: [area]
+files:
+  - [file:lines]
+---
+
+## Problem
+
+[problem description - enough context for future Claude to understand weeks later]
+
+## Solution
+
+[approach hints or "TBD"]
+```
+</step>
+
+<step name="update_state">
+If `.planning/STATE.md` exists:
+
+1. Count todos: `ls .planning/todos/pending/*.md 2>/dev/null | wc -l`
+2. Update "### Pending Todos" under "## Accumulated Context"
+</step>
+
+<step name="git_commit">
+Commit the todo and any updated state:
+
+```bash
+git add .planning/todos/pending/[filename]
+[ -f .planning/STATE.md ] && git add .planning/STATE.md
+git commit -m "$(cat <<'EOF'
+docs: capture todo - [title]
+
+Area: [area]
+EOF
+)"
+```
+
+Confirm: "Committed: docs: capture todo - [title]"
+</step>
+
+<step name="confirm">
+```
+Todo saved: .planning/todos/pending/[filename]
+
+  [title]
+  Area: [area]
+  Files: [count] referenced
+
+---
+
+Would you like to:
+
+1. Continue with current work
+2. Add another todo
+3. View all todos (/gsd/check-todos)
+```
+</step>
+
+</process>
+
+<output>
+- `.planning/todos/pending/[date]-[slug].md`
+- Updated `.planning/STATE.md` (if exists)
+</output>
+
+<anti_patterns>
+- Don't create todos for work in current plan (that's deviation rule territory)
+- Don't create elaborate solution sections — captures ideas, not plans
+- Don't block on missing information — "TBD" is fine
+</anti_patterns>
+
+<success_criteria>
+- [ ] Directory structure exists
+- [ ] Todo file created with valid frontmatter
+- [ ] Problem section has enough context for future Claude
+- [ ] No duplicates (checked and resolved)
+- [ ] Area consistent with existing todos
+- [ ] STATE.md updated if exists
+- [ ] Todo and state committed to git
+</success_criteria>

--- a/cursor-rules/gsd-check-todos.mdc
+++ b/cursor-rules/gsd-check-todos.mdc
@@ -1,0 +1,213 @@
+---
+description: "When user types /gsd/check-todos - List pending todos and select one to work on"
+globs:
+alwaysApply: false
+---
+
+# /gsd/check-todos
+
+<objective>
+List all pending todos, allow selection, load full context for the selected todo, and route to appropriate action.
+
+Enables reviewing captured ideas and deciding what to work on next.
+</objective>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md
+</context>
+
+<process>
+
+<step name="check_exist">
+```bash
+TODO_COUNT=$(ls .planning/todos/pending/*.md 2>/dev/null | wc -l | tr -d ' ')
+echo "Pending todos: $TODO_COUNT"
+```
+
+If count is 0:
+```
+No pending todos.
+
+Todos are captured during work sessions with /gsd/add-todo.
+
+---
+
+Would you like to:
+
+1. Continue with current phase (/gsd/progress)
+2. Add a todo now (/gsd/add-todo)
+```
+
+Exit.
+</step>
+
+<step name="parse_filter">
+Check for area filter in arguments:
+- `/gsd/check-todos` → show all
+- `/gsd/check-todos api` → filter to area:api only
+</step>
+
+<step name="list_todos">
+```bash
+for file in .planning/todos/pending/*.md; do
+  created=$(grep "^created:" "$file" | cut -d' ' -f2)
+  title=$(grep "^title:" "$file" | cut -d':' -f2- | xargs)
+  area=$(grep "^area:" "$file" | cut -d' ' -f2)
+  echo "$created|$title|$area|$file"
+done | sort
+```
+
+Apply area filter if specified. Display as numbered list:
+
+```
+Pending Todos:
+
+1. Add auth token refresh (api, 2d ago)
+2. Fix modal z-index issue (ui, 1d ago)
+3. Refactor database connection pool (database, 5h ago)
+
+---
+
+Reply with a number to view details, or:
+- `/gsd/check-todos [area]` to filter by area
+- `q` to exit
+```
+
+Format age as relative time.
+</step>
+
+<step name="handle_selection">
+Wait for user to reply with a number.
+
+If valid: load selected todo, proceed.
+If invalid: "Invalid selection. Reply with a number (1-[N]) or `q` to exit."
+</step>
+
+<step name="load_context">
+Read the todo file completely. Display:
+
+```
+## [title]
+
+**Area:** [area]
+**Created:** [date] ([relative time] ago)
+**Files:** [list or "None"]
+
+### Problem
+[problem section content]
+
+### Solution
+[solution section content]
+```
+
+If `files` field has entries, read and briefly summarize each.
+</step>
+
+<step name="check_roadmap">
+```bash
+ls .planning/ROADMAP.md 2>/dev/null && echo "Roadmap exists"
+```
+
+If roadmap exists:
+1. Check if todo's area matches an upcoming phase
+2. Check if todo's files overlap with a phase's scope
+3. Note any match for action options
+</step>
+
+<step name="offer_actions">
+**If todo maps to a roadmap phase:**
+
+Use AskUserQuestion:
+- header: "Action"
+- question: "This todo relates to Phase [N]: [name]. What would you like to do?"
+- options:
+  - "Work on it now" — move to done, start working
+  - "Add to phase plan" — include when planning Phase [N]
+  - "Brainstorm approach" — think through before deciding
+  - "Put it back" — return to list
+
+**If no roadmap match:**
+
+Use AskUserQuestion:
+- header: "Action"
+- question: "What would you like to do with this todo?"
+- options:
+  - "Work on it now" — move to done, start working
+  - "Create a phase" — /gsd/add-phase with this scope
+  - "Brainstorm approach" — think through before deciding
+  - "Put it back" — return to list
+</step>
+
+<step name="execute_action">
+**Work on it now:**
+```bash
+mv ".planning/todos/pending/[filename]" ".planning/todos/done/"
+```
+Update STATE.md todo count. Present problem/solution context. Begin work or ask how to proceed.
+
+**Add to phase plan:**
+Note todo reference in phase planning notes. Keep in pending. Return to list or exit.
+
+**Create a phase:**
+Display: `/gsd/add-phase [description from todo]`
+Keep in pending. User runs command in fresh context.
+
+**Brainstorm approach:**
+Keep in pending. Start discussion about problem and approaches.
+
+**Put it back:**
+Return to list_todos step.
+</step>
+
+<step name="update_state">
+After any action that changes todo count:
+
+```bash
+ls .planning/todos/pending/*.md 2>/dev/null | wc -l
+```
+
+Update STATE.md "### Pending Todos" section if exists.
+</step>
+
+<step name="git_commit">
+If todo was moved to done/, commit the change:
+
+```bash
+git add .planning/todos/done/[filename]
+git rm --cached .planning/todos/pending/[filename] 2>/dev/null || true
+[ -f .planning/STATE.md ] && git add .planning/STATE.md
+git commit -m "$(cat <<'EOF'
+docs: start work on todo - [title]
+
+Moved to done/, beginning implementation.
+EOF
+)"
+```
+
+Confirm: "Committed: docs: start work on todo - [title]"
+</step>
+
+</process>
+
+<output>
+- Moved todo to `.planning/todos/done/` (if "Work on it now")
+- Updated `.planning/STATE.md` (if todo count changed)
+</output>
+
+<anti_patterns>
+- Don't delete todos — move to done/ when work begins
+- Don't start work without moving to done/ first
+- Don't create plans from this command — route to /gsd/plan-phase or /gsd/add-phase
+</anti_patterns>
+
+<success_criteria>
+- [ ] All pending todos listed with title, area, age
+- [ ] Area filter applied if specified
+- [ ] Selected todo's full context loaded
+- [ ] Roadmap context checked for phase match
+- [ ] Appropriate actions offered
+- [ ] Selected action executed
+- [ ] STATE.md updated if todo count changed
+- [ ] Changes committed to git (if todo moved to done/)
+</success_criteria>

--- a/cursor-rules/gsd-complete-milestone.mdc
+++ b/cursor-rules/gsd-complete-milestone.mdc
@@ -1,0 +1,103 @@
+---
+description: "When user types /gsd/complete-milestone - Archive completed milestone and prepare for next version"
+globs:
+alwaysApply: false
+---
+
+# /gsd/complete-milestone
+
+<objective>
+Mark milestone {{version}} complete, archive to milestones/, and update ROADMAP.md.
+
+Purpose: Create historical record of shipped version, collapse completed work in roadmap, and prepare for next milestone.
+Output: Milestone archived, roadmap reorganized, git tagged.
+</objective>
+
+<execution_context>
+**Load these files NOW (before proceeding):**
+
+- Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/complete-milestone.md` (main workflow)
+- Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/milestone-archive.md` (archive template)
+  </execution_context>
+
+<context>
+**Project files:**
+- `.planning/ROADMAP.md`
+- `.planning/STATE.md`
+- `.planning/PROJECT.md`
+
+**User input:**
+
+- Version: {{version}} (e.g., "1.0", "1.1", "2.0")
+  </context>
+
+<process>
+
+**Follow complete-milestone.md workflow:**
+
+1. **Verify readiness:**
+
+   - Check all phases in milestone have completed plans (SUMMARY.md exists)
+   - Present milestone scope and stats
+   - Wait for confirmation
+
+2. **Gather stats:**
+
+   - Count phases, plans, tasks
+   - Calculate git range, file changes, LOC
+   - Extract timeline from git log
+   - Present summary, confirm
+
+3. **Extract accomplishments:**
+
+   - Read all phase SUMMARY.md files in milestone range
+   - Extract 4-6 key accomplishments
+   - Present for approval
+
+4. **Archive milestone:**
+
+   - Create `.planning/milestones/v{{version}}-ROADMAP.md`
+   - Extract full phase details from ROADMAP.md
+   - Fill milestone-archive.md template
+   - Update ROADMAP.md to one-line summary with link
+   - Offer to create next milestone
+
+5. **Update PROJECT.md:**
+
+   - Add "Current State" section with shipped version
+   - Add "Next Milestone Goals" section
+   - Archive previous content in `<details>` (if v1.1+)
+
+6. **Commit and tag:**
+
+   - Stage: MILESTONES.md, PROJECT.md, ROADMAP.md, STATE.md, archive file
+   - Commit: `chore: archive v{{version}} milestone`
+   - Tag: `git tag -a v{{version}} -m "[milestone summary]"`
+   - Ask about pushing tag
+
+7. **Offer next steps:**
+   - Plan next milestone
+   - Archive planning
+   - Done for now
+
+</process>
+
+<success_criteria>
+
+- Milestone archived to `.planning/milestones/v{{version}}-ROADMAP.md`
+- ROADMAP.md collapsed to one-line entry
+- PROJECT.md updated with current state
+- Git tag v{{version}} created
+- Commit successful
+- User knows next steps
+  </success_criteria>
+
+<critical_rules>
+
+- **Load workflow first:** Read complete-milestone.md before executing
+- **Verify completion:** All phases must have SUMMARY.md files
+- **User confirmation:** Wait for approval at verification gates
+- **Archive before collapsing:** Always create archive file before updating ROADMAP.md
+- **One-line summary:** Collapsed milestone in ROADMAP.md should be single line with link
+- **Context efficiency:** Archive keeps ROADMAP.md constant size
+  </critical_rules>

--- a/cursor-rules/gsd-consider-issues.mdc
+++ b/cursor-rules/gsd-consider-issues.mdc
@@ -1,0 +1,197 @@
+---
+description: "When user types /gsd/consider-issues - Review deferred issues with codebase context, close resolved ones, identify urgent ones"
+globs:
+alwaysApply: false
+---
+
+# /gsd/consider-issues
+
+<objective>
+Review all open issues from ISSUES.md with current codebase context. Identify which issues are resolved (can close), which are now urgent (should address), and which can continue waiting.
+
+This prevents issue pile-up by providing a triage mechanism with codebase awareness.
+</objective>
+
+<context>
+@.planning/ISSUES.md
+@.planning/STATE.md
+@.planning/ROADMAP.md
+</context>
+
+<process>
+
+<step name="verify">
+**Verify issues file exists:**
+
+If no `.planning/ISSUES.md`:
+```
+No issues file found.
+
+This means no enhancements have been deferred yet (Rule 5 hasn't triggered).
+
+Nothing to review.
+```
+Exit.
+
+If ISSUES.md exists but has no open issues (only template or empty "Open Enhancements"):
+```
+No open issues to review.
+
+All clear - continue with current work.
+```
+Exit.
+</step>
+
+<step name="parse">
+**Parse all open issues:**
+
+Extract from "## Open Enhancements" section:
+- ISS number (ISS-001, ISS-002, etc.)
+- Brief description
+- Discovered phase/date
+- Type (Performance/Refactoring/UX/Testing/Documentation/Accessibility)
+- Description details
+- Effort estimate
+
+Build list of issues to analyze.
+</step>
+
+<step name="analyze">
+**For each open issue, perform codebase analysis:**
+
+1. **Check if still relevant:**
+   - Search codebase for related code/files mentioned in issue
+   - If code no longer exists or was significantly refactored: likely resolved
+
+2. **Check if accidentally resolved:**
+   - Look for commits/changes that may have addressed this
+   - Check if the enhancement was implemented as part of other work
+
+3. **Assess current urgency:**
+   - Is this blocking upcoming phases?
+   - Has this become a pain point mentioned in recent summaries?
+   - Is this now affecting code we're actively working on?
+
+4. **Check natural fit:**
+   - Does this align with an upcoming phase in the roadmap?
+   - Would addressing it now touch the same files as current work?
+
+**Categorize each issue:**
+- **Resolved** - Can be closed (code changed, no longer applicable)
+- **Urgent** - Should address before continuing (blocking or causing problems)
+- **Natural fit** - Good candidate for upcoming phase X
+- **Can wait** - Keep deferred, no change in status
+</step>
+
+<step name="report">
+**Present categorized report:**
+
+```
+# Issue Review
+
+**Analyzed:** [N] open issues
+**Last reviewed:** [today's date]
+
+## Resolved (can close)
+
+### ISS-XXX: [description]
+**Reason:** [Why it's resolved - code changed, implemented elsewhere, no longer applicable]
+**Evidence:** [What you found - file changes, missing code, etc.]
+
+[Repeat for each resolved issue, or "None" if none resolved]
+
+---
+
+## Urgent (should address now)
+
+### ISS-XXX: [description]
+**Why urgent:** [What changed - blocking next phase, causing active problems, etc.]
+**Recommendation:** Insert plan before Phase [X] / Add to current phase
+**Effort:** [Quick/Medium/Substantial]
+
+[Repeat for each urgent issue, or "None - all issues can wait" if none urgent]
+
+---
+
+## Natural Fit for Upcoming Work
+
+### ISS-XXX: [description]
+**Fits with:** Phase [X] - [phase name]
+**Reason:** [Same files, same subsystem, natural inclusion]
+
+[Repeat for each, or "None" if no natural fits]
+
+---
+
+## Can Wait (no change)
+
+### ISS-XXX: [description]
+**Status:** Still valid, not urgent, keep deferred
+
+[Repeat for each, or list ISS numbers if many]
+```
+</step>
+
+<step name="offer_actions">
+**Offer batch actions:**
+
+Based on analysis, present options:
+
+```
+## Actions
+
+What would you like to do?
+```
+
+Use AskUserQuestion with appropriate options based on findings:
+
+**If resolved issues exist:**
+- "Close resolved issues" - Move to Closed Enhancements section
+- "Review each first" - Show details before closing
+
+**If urgent issues exist:**
+- "Insert urgent phase" - Create phase to address urgent issues (/gsd/insert-phase)
+- "Add to current plan" - Include in next plan being created
+- "Defer anyway" - Keep as-is despite urgency
+
+**If natural fits exist:**
+- "Note for phase planning" - Will be picked up during /gsd/plan-phase
+- "Add explicit reminder" - Update issue with "Include in Phase X"
+
+**Always include:**
+- "Done for now" - Exit without changes
+</step>
+
+<step name="execute_actions">
+**Execute selected actions:**
+
+**If closing resolved issues:**
+1. Read current ISSUES.md
+2. For each resolved issue:
+   - Remove from "## Open Enhancements"
+   - Add to "## Closed Enhancements" with resolution note:
+     ```
+     ### ISS-XXX: [description]
+     **Resolved:** [date] - [reason]
+     ```
+3. Write updated ISSUES.md
+4. Update STATE.md deferred issues count
+
+**If inserting urgent phase:**
+- Display the command for user to run after clearing: `/gsd/insert-phase [after-phase] Address urgent issues ISS-XXX, ISS-YYY`
+
+**If noting for phase planning:**
+- Update issue's "Suggested phase" field with specific phase number
+- These will be picked up by /gsd/plan-phase workflow
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] All open issues analyzed against current codebase
+- [ ] Each issue categorized (resolved/urgent/natural-fit/can-wait)
+- [ ] Clear reasoning provided for each categorization
+- [ ] Actions offered based on findings
+- [ ] ISSUES.md updated if user takes action
+- [ ] STATE.md updated if issue count changes
+</success_criteria>

--- a/cursor-rules/gsd-create-roadmap.mdc
+++ b/cursor-rules/gsd-create-roadmap.mdc
@@ -1,0 +1,112 @@
+---
+description: "When user types /gsd/create-roadmap - Create roadmap with phases for the project"
+globs:
+alwaysApply: false
+---
+
+# /gsd/create-roadmap
+
+<objective>
+Create project roadmap with phase breakdown.
+
+Roadmaps define what work happens in what order. Run after /gsd/new-project.
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/create-roadmap.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/roadmap.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/state.md`
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/config.json
+</context>
+
+<process>
+
+<step name="validate">
+Use Read to check for `.planning/PROJECT.md`.
+
+- If missing, output: `ERROR: No PROJECT.md found. Run /gsd/new-project first.` and exit.
+</step>
+
+<step name="check_existing">
+Check if roadmap already exists:
+
+Use Read to check for `.planning/ROADMAP.md`.
+
+- If it exists, set status to `ROADMAP_EXISTS`.
+- If it does not exist, set status to `NO_ROADMAP`.
+
+**If ROADMAP_EXISTS:**
+Use AskUserQuestion:
+- header: "Roadmap exists"
+- question: "A roadmap already exists. What would you like to do?"
+- options:
+  - "View existing" - Show current roadmap
+  - "Replace" - Create new roadmap (will overwrite)
+  - "Cancel" - Keep existing roadmap
+
+If "View existing": Read `.planning/ROADMAP.md` and exit
+If "Cancel": Exit
+If "Replace": Continue with workflow
+</step>
+
+<step name="create_roadmap">
+Follow the create-roadmap.md workflow starting from detect_domain step.
+
+The workflow handles:
+- Domain expertise detection
+- Phase identification
+- Research flags for each phase
+- Confirmation gates (respecting config mode)
+- ROADMAP.md creation
+- STATE.md initialization
+- Phase directory creation
+- Git commit
+</step>
+
+<step name="done">
+```
+Roadmap created:
+- Roadmap: .planning/ROADMAP.md
+- State: .planning/STATE.md
+- [N] phases defined
+
+---
+
+## ▶ Next Up
+
+**Phase 1: [Name]** — [Goal from ROADMAP.md]
+
+`/gsd/plan-phase 1`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `/gsd/discuss-phase 1` — gather context first
+- `/gsd/research-phase 1` — investigate unknowns
+- Review roadmap
+
+---
+```
+</step>
+
+</process>
+
+<output>
+- `.planning/ROADMAP.md`
+- `.planning/STATE.md`
+- `.planning/phases/XX-name/` directories
+</output>
+
+<success_criteria>
+- [ ] PROJECT.md validated
+- [ ] ROADMAP.md created with phases
+- [ ] STATE.md initialized
+- [ ] Phase directories created
+- [ ] Changes committed
+</success_criteria>

--- a/cursor-rules/gsd-debug.mdc
+++ b/cursor-rules/gsd-debug.mdc
@@ -1,0 +1,51 @@
+---
+description: "When user types /gsd/debug - Systematic debugging with persistent state across context resets"
+globs:
+alwaysApply: false
+---
+
+# /gsd/debug
+
+<objective>
+Debug issues using scientific method with a persistent debug document that survives `start a new chat`.
+
+If resuming (no arguments and active session exists): pick up where you left off.
+If starting new: gather symptoms, then investigate autonomously.
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/debug.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/DEBUG.md`
+</execution_context>
+
+<context>
+User's issue: $ARGUMENTS
+
+Check for active debug sessions:
+- Use Glob to list `.planning/debug/*.md`.
+- If any exist, show up to 5 results.
+</context>
+
+<process>
+Follow the workflow in Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/debug.md`
+
+**Quick reference:**
+
+1. **Check for active sessions** - Offer to resume or start new
+2. **Gather symptoms** - What happened? What should happen? Errors? When?
+3. **Create DEBUG.md** - Document symptoms in `.planning/debug/[slug].md`
+4. **Investigate** - Evidence → Hypothesis → Test → Eliminate or Confirm
+5. **Fix and verify** - Minimal fix, verify against original symptoms
+6. **Archive** - Move to `.planning/debug/resolved/`
+
+**Key principle:** The DEBUG.md is your memory. Update it constantly. It survives `start a new chat`.
+</process>
+
+<success_criteria>
+- [ ] Active sessions checked before starting new
+- [ ] Symptoms gathered through AskUserQuestion (not inline questions)
+- [ ] DEBUG.md tracks all investigation state
+- [ ] Scientific method followed (not random fixes)
+- [ ] Root cause confirmed with evidence before fixing
+- [ ] Fix verified and session archived
+</success_criteria>

--- a/cursor-rules/gsd-discuss-milestone.mdc
+++ b/cursor-rules/gsd-discuss-milestone.mdc
@@ -1,0 +1,50 @@
+---
+description: "When user types /gsd/discuss-milestone - Gather context for next milestone through adaptive questioning"
+globs:
+alwaysApply: false
+---
+
+# /gsd/discuss-milestone
+
+<objective>
+Help you figure out what to build in the next milestone through collaborative thinking.
+
+Purpose: After completing a milestone, explore what features you want to add, improve, or fix. Features first — scope and phases derive from what you want to build.
+Output: Context gathered, then routes to /gsd/new-milestone
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/discuss-milestone.md`
+</execution_context>
+
+<context>
+**Load project state first:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+
+**Load milestones (if exists):**
+@.planning/MILESTONES.md
+</context>
+
+<process>
+1. Verify previous milestone complete (or acknowledge active milestone)
+2. Present context from previous milestone (accomplishments, phase count)
+3. Follow discuss-milestone.md workflow with **ALL questions using AskUserQuestion**:
+   - Use AskUserQuestion: "What do you want to add, improve, or fix?" with feature categories
+   - Use AskUserQuestion to dig into features they mention
+   - Use AskUserQuestion to help them articulate what matters most
+   - Use AskUserQuestion for decision gate (ready / ask more / let me add context)
+4. Hand off to /gsd/new-milestone with gathered context
+
+**CRITICAL: ALL questions use AskUserQuestion. Never ask inline text questions.**
+</process>
+
+<success_criteria>
+
+- Project state loaded and presented
+- Previous milestone context summarized
+- Milestone scope gathered through adaptive questioning
+- Context handed off to /gsd/new-milestone
+  </success_criteria>

--- a/cursor-rules/gsd-discuss-phase.mdc
+++ b/cursor-rules/gsd-discuss-phase.mdc
@@ -1,0 +1,62 @@
+---
+description: "When user types /gsd/discuss-phase - Gather phase context through adaptive questioning before planning"
+globs:
+alwaysApply: false
+---
+
+# /gsd/discuss-phase
+
+<objective>
+Help the user articulate their vision for a phase through collaborative thinking.
+
+Purpose: Understand HOW the user imagines this phase working — what it looks like, what's essential, what's out of scope. You're a thinking partner helping them crystallize their vision, not an interviewer gathering technical requirements.
+
+Output: {phase}-CONTEXT.md capturing the user's vision for the phase
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/discuss-phase.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/context.md`
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+**Load project state first:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+</context>
+
+<process>
+1. Validate phase number argument (error if missing or invalid)
+2. Check if phase exists in roadmap
+3. Check if CONTEXT.md already exists (offer to update if yes)
+4. Follow discuss-phase.md workflow with **ALL questions using AskUserQuestion**:
+   - Present phase from roadmap
+   - Use AskUserQuestion: "How do you imagine this working?" with interpretation options
+   - Use AskUserQuestion to follow their thread — probe what excites them
+   - Use AskUserQuestion to sharpen the core — what's essential for THIS phase
+   - Use AskUserQuestion to find boundaries — what's explicitly out of scope
+   - Use AskUserQuestion for decision gate (ready / ask more / let me add context)
+   - Create CONTEXT.md capturing their vision
+5. Offer next steps (research or plan the phase)
+
+**CRITICAL: ALL questions use AskUserQuestion. Never ask inline text questions.**
+
+User is the visionary, you are the builder:
+- Ask about vision, feel, essential outcomes
+- DON'T ask about technical risks (you figure those out)
+- DON'T ask about codebase patterns (you read the code)
+- DON'T ask about success metrics (too corporate)
+- DON'T interrogate about constraints they didn't mention
+</process>
+
+<success_criteria>
+
+- Phase validated against roadmap
+- Vision gathered through collaborative thinking (not interrogation)
+- CONTEXT.md captures: how it works, what's essential, what's out of scope
+- User knows next steps (research or plan the phase)
+</success_criteria>

--- a/cursor-rules/gsd-execute-phase.mdc
+++ b/cursor-rules/gsd-execute-phase.mdc
@@ -1,0 +1,116 @@
+---
+description: "When user types /gsd/execute-phase - Execute all plans in a phase with intelligent parallelization"
+globs:
+alwaysApply: false
+---
+
+# /gsd/execute-phase
+
+<objective>
+Execute all unexecuted plans in a phase with parallel agent spawning.
+
+Analyzes plan dependencies to identify independent plans that can run concurrently.
+Spawns background agents for parallel execution, each agent commits its own tasks atomically.
+
+**Critical constraint:** One subagent per plan, always. This is for context isolation, not parallelization. Even strictly sequential plans spawn separate subagents so each starts with fresh 200k context at 0%.
+
+**Platform Support:**
+- **Claude Code:** Uses Task tool to spawn background subagents
+- **Cursor IDE:** Leverages Cursor's Agent Skills and native subagent system for parallel execution
+- **Antigravity:** Uses parallel tool calls (e.g., `browser_subagent`, `run_command` in parallel) or subagents to execute multiple plans concurrently
+
+Use this command when:
+- Phase has 2+ unexecuted plans
+- Want "walk away, come back to completed work" execution
+- Plans have clear dependency boundaries
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/execute-plan.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/execute-phase.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/summary.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/checkpoints.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/tdd.md`
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+@.planning/STATE.md
+@.planning/config.json
+</context>
+
+<process>
+1. Validate phase exists in roadmap
+2. Find all PLAN.md files without matching SUMMARY.md
+3. If 0 or 1 plans: suggest /gsd/execute-plan instead
+4. If 2+ plans: follow execute-phase.md workflow
+5. Monitor parallel agents until completion
+6. Present results and next steps
+</process>
+
+<execution_strategies>
+**Strategy A: Fully Autonomous** (no checkpoints)
+
+- Spawn subagent to execute entire plan
+- Subagent creates SUMMARY.md and commits
+- Main context: orchestration only (~5% usage)
+
+**Strategy B: Segmented** (has verify-only checkpoints)
+
+- Execute in segments between checkpoints
+- Subagent for autonomous segments
+- Main context for checkpoints
+- Aggregate results → SUMMARY → commit
+
+**Strategy C: Decision-Dependent** (has decision checkpoints)
+
+- Execute in main context
+- Decision outcomes affect subsequent tasks
+- Quality maintained through small scope (2-3 tasks per plan)
+</execution_strategies>
+
+<deviation_rules>
+During execution, handle discoveries automatically:
+
+1. **Auto-fix bugs** - Fix immediately, document in Summary
+2. **Auto-add critical** - Security/correctness gaps, add and document
+3. **Auto-fix blockers** - Can't proceed without fix, do it and document
+4. **Ask about architectural** - Major structural changes, stop and ask user
+5. **Log enhancements** - Nice-to-haves, log to ISSUES.md, continue
+
+Only rule 4 requires user intervention.
+</deviation_rules>
+
+<commit_rules>
+**Per-Task Commits:**
+
+After each task completes:
+1. Stage only files modified by that task
+2. Commit with format: `{type}({phase}-{plan}): {task-name}`
+3. Types: feat, fix, test, refactor, perf, chore
+4. Record commit hash for SUMMARY.md
+
+**Plan Metadata Commit:**
+
+After all tasks complete:
+1. Stage planning artifacts only: PLAN.md, SUMMARY.md, STATE.md, ROADMAP.md
+2. Commit with format: `docs({phase}-{plan}): complete [plan-name] plan`
+3. NO code files (already committed per-task)
+
+**NEVER use:**
+- `git add .`
+- `git add -A`
+- `git add src/` or any broad directory
+
+**Always stage files individually.**
+</commit_rules>
+
+<success_criteria>
+- [ ] All independent plans executed in parallel
+- [ ] Dependent plans executed after dependencies complete
+- [ ] Each task committed individually (feat/fix/test/refactor)
+- [ ] All SUMMARY.md files created
+- [ ] Metadata committed by orchestrator
+- [ ] Phase progress updated
+</success_criteria>

--- a/cursor-rules/gsd-execute-plan.mdc
+++ b/cursor-rules/gsd-execute-plan.mdc
@@ -1,0 +1,121 @@
+---
+description: "When user types /gsd/execute-plan - Execute a PLAN.md file"
+globs:
+alwaysApply: false
+---
+
+# /gsd/execute-plan
+
+<objective>
+Execute a PLAN.md file with per-task atomic commits, create SUMMARY.md, update project state.
+
+Commit strategy:
+- Each task → 1 commit immediately after completion (feat/fix/test/refactor)
+- Plan completion → 1 metadata commit (docs: SUMMARY + STATE + ROADMAP)
+
+Uses intelligent segmentation:
+- Plans without checkpoints → spawn subagent for full autonomous execution
+- Plans with verify checkpoints → segment execution, pause at checkpoints
+- Plans with decision checkpoints → execute in main context
+  </objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/execute-plan.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/summary.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/checkpoints.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/tdd.md`
+</execution_context>
+
+<context>
+Plan path: $ARGUMENTS
+
+**Load project state first:**
+@.planning/STATE.md
+
+**Load workflow config:**
+@.planning/config.json
+</context>
+
+<process>
+1. Check .planning/ directory exists (error if not - user should run /gsd/new-project)
+2. Verify plan at $ARGUMENTS exists
+3. Check if SUMMARY.md already exists (plan already executed?)
+4. Load workflow config for mode (interactive/yolo)
+5. Follow execute-plan.md workflow:
+   - Parse plan and determine execution strategy (A/B/C)
+   - Execute tasks (via subagent or main context as appropriate)
+   - Handle checkpoints and deviations
+   - Create SUMMARY.md
+   - Update STATE.md
+   - Commit changes
+</process>
+
+<execution_strategies>
+**Strategy A: Fully Autonomous** (no checkpoints)
+
+- Spawn subagent to execute entire plan
+- Subagent creates SUMMARY.md and commits
+- Main context: orchestration only (~5% usage)
+
+**Strategy B: Segmented** (has verify-only checkpoints)
+
+- Execute in segments between checkpoints
+- Subagent for autonomous segments
+- Main context for checkpoints
+- Aggregate results → SUMMARY → commit
+
+**Strategy C: Decision-Dependent** (has decision checkpoints)
+
+- Execute in main context
+- Decision outcomes affect subsequent tasks
+- Quality maintained through small scope (2-3 tasks per plan)
+  </execution_strategies>
+
+<deviation_rules>
+During execution, handle discoveries automatically:
+
+1. **Auto-fix bugs** - Fix immediately, document in Summary
+2. **Auto-add critical** - Security/correctness gaps, add and document
+3. **Auto-fix blockers** - Can't proceed without fix, do it and document
+4. **Ask about architectural** - Major structural changes, stop and ask user
+5. **Log enhancements** - Nice-to-haves, log to ISSUES.md, continue
+
+Only rule 4 requires user intervention.
+</deviation_rules>
+
+<commit_rules>
+**Per-Task Commits:**
+
+After each task completes:
+1. Stage only files modified by that task
+2. Commit with format: `{type}({phase}-{plan}): {task-name}`
+3. Types: feat, fix, test, refactor, perf, chore
+4. Record commit hash for SUMMARY.md
+
+**Plan Metadata Commit:**
+
+After all tasks complete:
+1. Stage planning artifacts only: PLAN.md, SUMMARY.md, STATE.md, ROADMAP.md
+2. Commit with format: `docs({phase}-{plan}): complete [plan-name] plan`
+3. NO code files (already committed per-task)
+
+**NEVER use:**
+- `git add .`
+- `git add -A`
+- `git add src/` or any broad directory
+
+**Always stage files individually.**
+
+See /mnt/c/Users/jrm22n/.cursor/get-shit-done/references/git-integration.md for full commit strategy.
+</commit_rules>
+
+<success_criteria>
+
+- [ ] All tasks executed
+- [ ] Each task committed individually (feat/fix/test/refactor)
+- [ ] SUMMARY.md created with substantive content and commit hashes
+- [ ] STATE.md updated (position, decisions, issues, session)
+- [ ] ROADMAP updated (plan count, phase status)
+- [ ] Metadata committed with docs({phase}-{plan}): complete [plan-name] plan
+- [ ] User informed of next steps
+      </success_criteria>

--- a/cursor-rules/gsd-help.mdc
+++ b/cursor-rules/gsd-help.mdc
@@ -1,0 +1,404 @@
+---
+description: "When user types /gsd/help - Show available GSD commands and usage guide"
+globs:
+alwaysApply: false
+---
+
+# /gsd/help
+
+<objective>
+Display the complete GSD command reference.
+
+Output ONLY the reference content below. Do NOT add:
+
+- Project-specific analysis
+- Git status or file context
+- Next-step suggestions
+- Any commentary beyond the reference
+  </objective>
+
+<reference>
+# GSD Command Reference
+
+**GSD** (Get Shit Done) creates hierarchical project plans optimized for solo agentic development with Claude Code.
+
+## Quick Start
+
+1. `/gsd/new-project` - Initialize project with brief
+2. `/gsd/create-roadmap` - Create roadmap and phases
+3. `/gsd/plan-phase <number>` - Create detailed plan for first phase
+4. `/gsd/execute-plan <path>` - Execute the plan
+
+## Core Workflow
+
+```
+Initialization → Planning → Execution → Milestone Completion
+```
+
+### Project Initialization
+
+**`/gsd/new-project`**
+Initialize new project with brief and configuration.
+
+- Creates `.planning/PROJECT.md` (vision and requirements)
+- Creates `.planning/config.json` (workflow mode)
+- Asks for workflow mode (interactive/yolo) upfront
+- Commits initialization files to git
+
+Usage: `/gsd/new-project`
+
+**`/gsd/create-roadmap`**
+Create roadmap and state tracking for initialized project.
+
+- Creates `.planning/ROADMAP.md` (phase breakdown)
+- Creates `.planning/STATE.md` (project memory)
+- Creates `.planning/phases/` directories
+
+Usage: `/gsd/create-roadmap`
+
+**`/gsd/map-codebase`**
+Map an existing codebase for brownfield projects.
+
+- Analyzes codebase with parallel Explore agents
+- Creates `.planning/codebase/` with 7 focused documents
+- Covers stack, architecture, structure, conventions, testing, integrations, concerns
+- Use before `/gsd/new-project` on existing codebases
+
+Usage: `/gsd/map-codebase`
+
+### Phase Planning
+
+**`/gsd/discuss-phase <number>`**
+Help articulate your vision for a phase before planning.
+
+- Captures how you imagine this phase working
+- Creates CONTEXT.md with your vision, essentials, and boundaries
+- Use when you have ideas about how something should look/feel
+
+Usage: `/gsd/discuss-phase 2`
+
+**`/gsd/research-phase <number>`**
+Comprehensive ecosystem research for niche/complex domains.
+
+- Discovers standard stack, architecture patterns, pitfalls
+- Creates RESEARCH.md with "how experts build this" knowledge
+- Use for 3D, games, audio, shaders, ML, and other specialized domains
+- Goes beyond "which library" to ecosystem knowledge
+
+Usage: `/gsd/research-phase 3`
+
+**`/gsd/list-phase-assumptions <number>`**
+See what Claude is planning to do before it starts.
+
+- Shows Claude's intended approach for a phase
+- Lets you course-correct if Claude misunderstood your vision
+- No files created - conversational output only
+
+Usage: `/gsd/list-phase-assumptions 3`
+
+**`/gsd/plan-phase <number>`**
+Create detailed execution plan for a specific phase.
+
+- Generates `.planning/phases/XX-phase-name/XX-YY-PLAN.md`
+- Breaks phase into concrete, actionable tasks
+- Includes verification criteria and success measures
+- Multiple plans per phase supported (XX-01, XX-02, etc.)
+
+Usage: `/gsd/plan-phase 1`
+Result: Creates `.planning/phases/01-foundation/01-01-PLAN.md`
+
+### Execution
+
+**`/gsd/execute-plan <path>`**
+Execute a single PLAN.md file.
+
+- Runs plan tasks sequentially
+- Creates SUMMARY.md after completion
+- Updates STATE.md with accumulated context
+- Use for interactive execution with checkpoints
+
+Usage: `/gsd/execute-plan .planning/phases/01-foundation/01-01-PLAN.md`
+
+**`/gsd/execute-phase <phase-number>`**
+Execute all unexecuted plans in a phase with parallel background agents.
+
+- Analyzes plan dependencies and spawns independent plans concurrently
+- Use when phase has 2+ plans and you want "walk away" execution
+- Respects max_concurrent_agents from config.json
+
+Usage: `/gsd/execute-phase 5`
+
+Options (via `.planning/config.json` parallelization section):
+- `max_concurrent_agents`: Limit parallel agents (default: 3)
+- `skip_checkpoints`: Skip human checkpoints in background (default: true)
+- `min_plans_for_parallel`: Minimum plans to trigger parallelization (default: 2)
+
+**`/gsd/status [--wait]`**
+Check status of background agents from parallel execution.
+
+- Shows running/completed agents from agent-history.json
+- Uses TaskOutput to poll agent status
+- With `--wait`: blocks until all agents complete
+
+Usage: `/gsd/status` or `/gsd/status --wait`
+
+### Roadmap Management
+
+**`/gsd/add-phase <description>`**
+Add new phase to end of current milestone.
+
+- Appends to ROADMAP.md
+- Uses next sequential number
+- Updates phase directory structure
+
+Usage: `/gsd/add-phase "Add admin dashboard"`
+
+**`/gsd/insert-phase <after> <description>`**
+Insert urgent work as decimal phase between existing phases.
+
+- Creates intermediate phase (e.g., 7.1 between 7 and 8)
+- Useful for discovered work that must happen mid-milestone
+- Maintains phase ordering
+
+Usage: `/gsd/insert-phase 7 "Fix critical auth bug"`
+Result: Creates Phase 7.1
+
+**`/gsd/remove-phase <number>`**
+Remove a future phase and renumber subsequent phases.
+
+- Deletes phase directory and all references
+- Renumbers all subsequent phases to close the gap
+- Only works on future (unstarted) phases
+- Git commit preserves historical record
+
+Usage: `/gsd/remove-phase 17`
+Result: Phase 17 deleted, phases 18-20 become 17-19
+
+### Milestone Management
+
+**`/gsd/discuss-milestone`**
+Figure out what you want to build in the next milestone.
+
+- Reviews what shipped in previous milestone
+- Helps you identify features to add, improve, or fix
+- Routes to /gsd/new-milestone when ready
+
+Usage: `/gsd/discuss-milestone`
+
+**`/gsd/new-milestone <name>`**
+Create a new milestone with phases for an existing project.
+
+- Adds milestone section to ROADMAP.md
+- Creates phase directories
+- Updates STATE.md for new milestone
+
+Usage: `/gsd/new-milestone "v2.0 Features"`
+
+**`/gsd/complete-milestone <version>`**
+Archive completed milestone and prepare for next version.
+
+- Creates MILESTONES.md entry with stats
+- Archives full details to milestones/ directory
+- Creates git tag for the release
+- Prepares workspace for next version
+
+Usage: `/gsd/complete-milestone 1.0.0`
+
+### Progress Tracking
+
+**`/gsd/progress`**
+Check project status and intelligently route to next action.
+
+- Shows visual progress bar and completion percentage
+- Summarizes recent work from SUMMARY files
+- Displays current position and what's next
+- Lists key decisions and open issues
+- Offers to execute next plan or create it if missing
+- Detects 100% milestone completion
+
+Usage: `/gsd/progress`
+
+### Session Management
+
+**`/gsd/resume-work`**
+Resume work from previous session with full context restoration.
+
+- Reads STATE.md for project context
+- Shows current position and recent progress
+- Offers next actions based on project state
+
+Usage: `/gsd/resume-work`
+
+**`/gsd/pause-work`**
+Create context handoff when pausing work mid-phase.
+
+- Creates .continue-here file with current state
+- Updates STATE.md session continuity section
+- Captures in-progress work context
+
+Usage: `/gsd/pause-work`
+
+### Issue Management
+
+**`/gsd/consider-issues`**
+Review deferred issues with codebase context.
+
+- Analyzes all open issues against current codebase state
+- Identifies resolved issues (can close)
+- Identifies urgent issues (should address now)
+- Identifies natural fits for upcoming phases
+- Offers batch actions (close, insert phase, note for planning)
+
+Usage: `/gsd/consider-issues`
+
+### Debugging
+
+**`/gsd/debug [issue description]`**
+Systematic debugging with persistent state across context resets.
+
+- Gathers symptoms through adaptive questioning
+- Creates `.planning/debug/[slug].md` to track investigation
+- Investigates using scientific method (evidence → hypothesis → test)
+- Survives `start a new chat` — run `/gsd/debug` with no args to resume
+- Archives resolved issues to `.planning/debug/resolved/`
+
+Usage: `/gsd/debug "login button doesn't work"`
+Usage: `/gsd/debug` (resume active session)
+
+### Todo Management
+
+**`/gsd/add-todo [description]`**
+Capture idea or task as todo from current conversation.
+
+- Extracts context from conversation (or uses provided description)
+- Creates structured todo file in `.planning/todos/pending/`
+- Infers area from file paths for grouping
+- Checks for duplicates before creating
+- Updates STATE.md todo count
+
+Usage: `/gsd/add-todo` (infers from conversation)
+Usage: `/gsd/add-todo Add auth token refresh`
+
+**`/gsd/check-todos [area]`**
+List pending todos and select one to work on.
+
+- Lists all pending todos with title, area, age
+- Optional area filter (e.g., `/gsd/check-todos api`)
+- Loads full context for selected todo
+- Routes to appropriate action (work now, add to phase, brainstorm)
+- Moves todo to done/ when work begins
+
+Usage: `/gsd/check-todos`
+Usage: `/gsd/check-todos api`
+
+### Utility Commands
+
+**`/gsd/help`**
+Show this command reference.
+
+## Files & Structure
+
+```
+.planning/
+├── PROJECT.md            # Project vision
+├── ROADMAP.md            # Current phase breakdown
+├── STATE.md              # Project memory & context
+├── ISSUES.md             # Deferred enhancements (created when needed)
+├── config.json           # Workflow mode & gates
+├── todos/                # Captured ideas and tasks
+│   ├── pending/          # Todos waiting to be worked on
+│   └── done/             # Completed todos
+├── debug/                # Active debug sessions
+│   └── resolved/         # Archived resolved issues
+├── codebase/             # Codebase map (brownfield projects)
+│   ├── STACK.md          # Languages, frameworks, dependencies
+│   ├── ARCHITECTURE.md   # Patterns, layers, data flow
+│   ├── STRUCTURE.md      # Directory layout, key files
+│   ├── CONVENTIONS.md    # Coding standards, naming
+│   ├── TESTING.md        # Test setup, patterns
+│   ├── INTEGRATIONS.md   # External services, APIs
+│   └── CONCERNS.md       # Tech debt, known issues
+└── phases/
+    ├── 01-foundation/
+    │   ├── 01-01-PLAN.md
+    │   └── 01-01-SUMMARY.md
+    └── 02-core-features/
+        ├── 02-01-PLAN.md
+        └── 02-01-SUMMARY.md
+```
+
+## Workflow Modes
+
+Set during `/gsd/new-project`:
+
+**Interactive Mode**
+
+- Confirms each major decision
+- Pauses at checkpoints for approval
+- More guidance throughout
+
+**YOLO Mode**
+
+- Auto-approves most decisions
+- Executes plans without confirmation
+- Only stops for critical checkpoints
+
+Change anytime by editing `.planning/config.json`
+
+## Common Workflows
+
+**Starting a new project:**
+
+```
+/gsd/new-project
+/gsd/create-roadmap
+/gsd/plan-phase 1
+/gsd/execute-plan .planning/phases/01-foundation/01-01-PLAN.md
+```
+
+**Resuming work after a break:**
+
+```
+/gsd/progress  # See where you left off and continue
+```
+
+**Adding urgent mid-milestone work:**
+
+```
+/gsd/insert-phase 5 "Critical security fix"
+/gsd/plan-phase 5.1
+/gsd/execute-plan .planning/phases/05.1-critical-security-fix/05.1-01-PLAN.md
+```
+
+**Completing a milestone:**
+
+```
+/gsd/complete-milestone 1.0.0
+/gsd/new-project  # Start next milestone
+```
+
+**Capturing ideas during work:**
+
+```
+/gsd/add-todo                    # Capture from conversation context
+/gsd/add-todo Fix modal z-index  # Capture with explicit description
+/gsd/check-todos                 # Review and work on todos
+/gsd/check-todos api             # Filter by area
+```
+
+**Debugging an issue:**
+
+```
+/gsd/debug "form submission fails silently"  # Start debug session
+# ... investigation happens, context fills up ...
+/clear
+/gsd/debug                                    # Resume from where you left off
+```
+
+## Getting Help
+
+- Read `.planning/PROJECT.md` for project vision
+- Read `.planning/STATE.md` for current context
+- Check `.planning/ROADMAP.md` for phase status
+- Run `/gsd/progress` to check where you're up to
+  </reference>

--- a/cursor-rules/gsd-insert-phase.mdc
+++ b/cursor-rules/gsd-insert-phase.mdc
@@ -1,0 +1,225 @@
+---
+description: "When user types /gsd/insert-phase - Insert urgent work as decimal phase (e.g., 72.1) between existing phases"
+globs:
+alwaysApply: false
+---
+
+# /gsd/insert-phase
+
+<objective>
+Insert a decimal phase for urgent work discovered mid-milestone that must be completed between existing integer phases.
+
+Uses decimal numbering (72.1, 72.2, etc.) to preserve the logical sequence of planned phases while accommodating urgent insertions.
+
+Purpose: Handle urgent work discovered during execution without renumbering entire roadmap.
+</objective>
+
+<execution_context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</execution_context>
+
+<process>
+
+<step name="parse_arguments">
+Parse the command arguments:
+- First argument: integer phase number to insert after
+- Remaining arguments: phase description
+
+Example: `/gsd/insert-phase 72 Fix critical auth bug`
+→ after = 72
+→ description = "Fix critical auth bug"
+
+Validation:
+
+```bash
+if [ $# -lt 2 ]; then
+  echo "ERROR: Both phase number and description required"
+  echo "Usage: /gsd/insert-phase <after> <description>"
+  echo "Example: /gsd/insert-phase 72 Fix critical auth bug"
+  exit 1
+fi
+```
+
+Parse first argument as integer:
+
+```bash
+after_phase=$1
+shift
+description="$*"
+
+# Validate after_phase is an integer
+if ! [[ "$after_phase" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: Phase number must be an integer"
+  exit 1
+fi
+```
+
+</step>
+
+<step name="load_roadmap">
+Load the roadmap file:
+
+```bash
+if [ -f .planning/ROADMAP.md ]; then
+  ROADMAP=".planning/ROADMAP.md"
+else
+  echo "ERROR: No roadmap found (.planning/ROADMAP.md)"
+  exit 1
+fi
+```
+
+Read roadmap content for parsing.
+</step>
+
+<step name="verify_target_phase">
+Verify that the target phase exists in the roadmap:
+
+1. Search for "### Phase {after_phase}:" heading
+2. If not found:
+
+   ```
+   ERROR: Phase {after_phase} not found in roadmap
+   Available phases: [list phase numbers]
+   ```
+
+   Exit.
+
+3. Verify phase is in current milestone (not completed/archived)
+   </step>
+
+<step name="find_existing_decimals">
+Find existing decimal phases after the target phase:
+
+1. Search for all "### Phase {after_phase}.N:" headings
+2. Extract decimal suffixes (e.g., for Phase 72: find 72.1, 72.2, 72.3)
+3. Find the highest decimal suffix
+4. Calculate next decimal: max + 1
+
+Examples:
+
+- Phase 72 with no decimals → next is 72.1
+- Phase 72 with 72.1 → next is 72.2
+- Phase 72 with 72.1, 72.2 → next is 72.3
+
+Store as: `decimal_phase="$(printf "%02d" $after_phase).${next_decimal}"`
+</step>
+
+<step name="generate_slug">
+Convert the phase description to a kebab-case slug:
+
+```bash
+slug=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+```
+
+Phase directory name: `{decimal-phase}-{slug}`
+Example: `06.1-fix-critical-auth-bug` (phase 6 insertion)
+</step>
+
+<step name="create_phase_directory">
+Create the phase directory structure:
+
+```bash
+phase_dir=".planning/phases/${decimal_phase}-${slug}"
+mkdir -p "$phase_dir"
+```
+
+Confirm: "Created directory: $phase_dir"
+</step>
+
+<step name="update_roadmap">
+Insert the new phase entry into the roadmap:
+
+1. Find insertion point: immediately after Phase {after_phase}'s content (before next phase heading or "---")
+2. Insert new phase heading with (INSERTED) marker:
+
+   ```
+   ### Phase {decimal_phase}: {Description} (INSERTED)
+
+   **Goal:** [Urgent work - to be planned]
+   **Depends on:** Phase {after_phase}
+   **Plans:** 0 plans
+
+   Plans:
+   - [ ] TBD (run /gsd/plan-phase {decimal_phase} to break down)
+
+   **Details:**
+   [To be added during planning]
+   ```
+
+3. Write updated roadmap back to file
+
+The "(INSERTED)" marker helps identify decimal phases as urgent insertions.
+
+Preserve all other content exactly (formatting, spacing, other phases).
+</step>
+
+<step name="update_project_state">
+Update STATE.md to reflect the inserted phase:
+
+1. Read `.planning/STATE.md`
+2. Under "## Accumulated Context" → "### Roadmap Evolution" add entry:
+   ```
+   - Phase {decimal_phase} inserted after Phase {after_phase}: {description} (URGENT)
+   ```
+
+If "Roadmap Evolution" section doesn't exist, create it.
+
+Add note about insertion reason if appropriate.
+</step>
+
+<step name="completion">
+Present completion summary:
+
+```
+Phase {decimal_phase} inserted after Phase {after_phase}:
+- Description: {description}
+- Directory: .planning/phases/{decimal-phase}-{slug}/
+- Status: Not planned yet
+- Marker: (INSERTED) - indicates urgent work
+
+Roadmap updated: {roadmap-path}
+Project state updated: .planning/STATE.md
+
+---
+
+## ▶ Next Up
+
+**Phase {decimal_phase}: {description}** — urgent insertion
+
+`/gsd/plan-phase {decimal_phase}`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- Review insertion impact: Check if Phase {next_integer} dependencies still make sense
+- Review roadmap
+
+---
+```
+</step>
+
+</process>
+
+<anti_patterns>
+
+- Don't use this for planned work at end of milestone (use /gsd/add-phase)
+- Don't insert before Phase 1 (decimal 0.1 makes no sense)
+- Don't renumber existing phases
+- Don't modify the target phase content
+- Don't create plans yet (that's /gsd/plan-phase)
+- Don't commit changes (user decides when to commit)
+  </anti_patterns>
+
+<success_criteria>
+Phase insertion is complete when:
+
+- [ ] Phase directory created: `.planning/phases/{N.M}-{slug}/`
+- [ ] Roadmap updated with new phase entry (includes "(INSERTED)" marker)
+- [ ] Phase inserted in correct position (after target phase, before next integer phase)
+- [ ] STATE.md updated with roadmap evolution note
+- [ ] Decimal number calculated correctly (based on existing decimals)
+- [ ] User informed of next steps and dependency implications
+      </success_criteria>

--- a/cursor-rules/gsd-list-phase-assumptions.mdc
+++ b/cursor-rules/gsd-list-phase-assumptions.mdc
@@ -1,0 +1,47 @@
+---
+description: "When user types /gsd/list-phase-assumptions - Surface Claude's assumptions about a phase approach before planning"
+globs:
+alwaysApply: false
+---
+
+# /gsd/list-phase-assumptions
+
+<objective>
+Analyze a phase and present Claude's assumptions about technical approach, implementation order, scope boundaries, risk areas, and dependencies.
+
+Purpose: Help users see what Claude thinks BEFORE planning begins - enabling course correction early when assumptions are wrong.
+Output: Conversational output only (no file creation) - ends with "What do you think?" prompt
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/list-phase-assumptions.md`
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+**Load project state first:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+</context>
+
+<process>
+1. Validate phase number argument (error if missing or invalid)
+2. Check if phase exists in roadmap
+3. Follow list-phase-assumptions.md workflow:
+   - Analyze roadmap description
+   - Surface assumptions about: technical approach, implementation order, scope, risks, dependencies
+   - Present assumptions clearly
+   - Prompt "What do you think?"
+4. Gather feedback and offer next steps
+</process>
+
+<success_criteria>
+
+- Phase validated against roadmap
+- Assumptions surfaced across five areas
+- User prompted for feedback
+- User knows next steps (discuss context, plan phase, or correct assumptions)
+  </success_criteria>

--- a/cursor-rules/gsd-map-codebase.mdc
+++ b/cursor-rules/gsd-map-codebase.mdc
@@ -1,0 +1,79 @@
+---
+description: "When user types /gsd/map-codebase - Analyze codebase with parallel Explore agents to produce .planning/codebase/ documents"
+globs:
+alwaysApply: false
+---
+
+# /gsd/map-codebase
+
+<objective>
+Analyze existing codebase using parallel Explore agents to produce structured codebase documents.
+
+This command spawns multiple Explore agents to analyze different aspects of the codebase in parallel, each with fresh context.
+
+Output: .planning/codebase/ folder with 7 structured documents about the codebase state.
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/map-codebase.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/stack.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/architecture.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/structure.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/conventions.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/testing.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/integrations.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/codebase/concerns.md`
+</execution_context>
+
+<context>
+Focus area: $ARGUMENTS (optional - if provided, tells agents to focus on specific subsystem)
+
+**Load project state if exists:**
+Check for .planning/STATE.md - loads context if project already initialized
+
+**This command can run:**
+- Before /gsd/new-project (brownfield codebases) - creates codebase map first
+- After /gsd/new-project (greenfield codebases) - updates codebase map as code evolves
+- Anytime to refresh codebase understanding
+</context>
+
+<when_to_use>
+**Use map-codebase for:**
+- Brownfield projects before initialization (understand existing code first)
+- Refreshing codebase map after significant changes
+- Onboarding to an unfamiliar codebase
+- Before major refactoring (understand current state)
+- When STATE.md references outdated codebase info
+
+**Skip map-codebase for:**
+- Greenfield projects with no code yet (nothing to map)
+- Trivial codebases (<5 files)
+</when_to_use>
+
+<process>
+1. Check if .planning/codebase/ already exists (offer to refresh or skip)
+2. Create .planning/codebase/ directory structure
+3. Spawn 4 parallel Explore agents to analyze codebase:
+   - Agent 1: Stack + Integrations (technology focus)
+   - Agent 2: Architecture + Structure (organization focus)
+   - Agent 3: Conventions + Testing (quality focus)
+   - Agent 4: Concerns (issues focus)
+4. Wait for all agents to complete, collect findings
+5. Write 7 codebase documents using templates:
+   - STACK.md - Languages, frameworks, key dependencies
+   - ARCHITECTURE.md - System design, patterns, data flow
+   - STRUCTURE.md - Directory layout, module organization
+   - CONVENTIONS.md - Code style, naming, patterns
+   - TESTING.md - Test structure, coverage, practices
+   - INTEGRATIONS.md - APIs, databases, external services
+   - CONCERNS.md - Technical debt, risks, issues
+6. Offer next steps (typically: /gsd/new-project or /gsd/plan-phase)
+</process>
+
+<success_criteria>
+- [ ] .planning/codebase/ directory created
+- [ ] All 7 codebase documents written
+- [ ] Documents follow template structure
+- [ ] Parallel agents completed without errors
+- [ ] User knows next steps
+</success_criteria>

--- a/cursor-rules/gsd-new-milestone.mdc
+++ b/cursor-rules/gsd-new-milestone.mdc
@@ -1,0 +1,61 @@
+---
+description: "When user types /gsd/new-milestone - Create a new milestone with phases for an existing project"
+globs:
+alwaysApply: false
+---
+
+# /gsd/new-milestone
+
+<objective>
+Create a new milestone for an existing project with defined phases.
+
+Purpose: After completing a milestone (or when ready to define next chunk of work), creates the milestone structure in ROADMAP.md with phases, updates STATE.md, and creates phase directories.
+Output: New milestone in ROADMAP.md, updated STATE.md, phase directories created
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/create-milestone.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/roadmap.md`
+</execution_context>
+
+<context>
+Milestone name: $ARGUMENTS (optional - will prompt if not provided)
+
+**Load project state first:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+
+**Load milestones (if exists):**
+@.planning/MILESTONES.md
+</context>
+
+<process>
+1. Load project context (STATE.md, ROADMAP.md, MILESTONES.md)
+2. Calculate next milestone version and starting phase number
+3. If milestone name provided in arguments, use it; otherwise prompt
+4. Gather phases (per depth setting: quick 3-5, standard 5-8, comprehensive 8-12):
+   - If called from /gsd/discuss-milestone, use provided context
+   - Otherwise, prompt for phase breakdown
+5. Detect research needs for each phase
+6. Confirm phases (respect config.json gate settings)
+7. Follow create-milestone.md workflow:
+   - Update ROADMAP.md with new milestone section
+   - Create phase directories
+   - Update STATE.md for new milestone
+   - Git commit milestone creation
+8. Offer next steps (discuss first phase, plan first phase, review)
+</process>
+
+<success_criteria>
+
+- Next phase number calculated correctly (continues from previous milestone)
+- Phases defined per depth setting (quick: 3-5, standard: 5-8, comprehensive: 8-12)
+- Research flags assigned for each phase
+- ROADMAP.md updated with new milestone section
+- Phase directories created
+- STATE.md reset for new milestone
+- Git commit made
+- User knows next steps
+  </success_criteria>

--- a/cursor-rules/gsd-new-project.mdc
+++ b/cursor-rules/gsd-new-project.mdc
@@ -1,0 +1,324 @@
+---
+description: "When user types /gsd/new-project - Initialize a new project with deep context gathering and PROJECT.md"
+globs:
+alwaysApply: false
+---
+
+# /gsd/new-project
+
+<objective>
+
+Initialize a new project through comprehensive context gathering.
+
+This is the most leveraged moment in any project. Deep questioning here means better plans, better execution, better outcomes.
+
+Creates `.planning/` with PROJECT.md and config.json.
+
+</objective>
+
+<execution_context>
+
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/principles.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/questioning.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/project.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/config.json`
+
+</execution_context>
+
+<process>
+
+<step name="setup">
+
+**MANDATORY FIRST STEP — Execute these checks before ANY user interaction:**
+
+1. **Abort if project exists:**
+   - Use Read to check for `.planning/PROJECT.md`.
+   - If it exists, output: `ERROR: Project already initialized. Use /gsd/progress` and exit.
+
+2. **Initialize git repo in THIS directory** (required even if inside a parent repo):
+   - Use Glob to check for a `.git` directory or `.git` file in the current directory (worktrees use a file).
+   - If neither exists, run `git init` in the current directory.
+
+3. **Detect existing code (brownfield detection):**
+   - Use Glob to collect up to 20 files with extensions: `.ts`, `.js`, `.py`, `.go`, `.rs`, `.swift`, `.java`.
+   - Ignore matches under `node_modules/` or `.git/`.
+   - Use Read to check for package manifests: `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`, `Package.swift`.
+   - Use Glob to check whether `.planning/codebase/` exists (any files under it).
+   - Record:
+     - `CODE_FILES` = list of matching files (up to 20)
+     - `HAS_PACKAGE` = "yes" if any manifest exists
+     - `HAS_CODEBASE_MAP` = "yes" if `.planning/codebase/` exists
+
+   **You MUST complete the checks above using Read/Glob tools before proceeding.**
+
+</step>
+
+<step name="brownfield_offer">
+
+**If existing code detected and .planning/codebase/ doesn't exist:**
+
+Check the results from setup step:
+- If `CODE_FILES` is non-empty OR `HAS_PACKAGE` is "yes"
+- AND `HAS_CODEBASE_MAP` is NOT "yes"
+
+Use AskUserQuestion:
+- header: "Existing Code"
+- question: "I detected existing code in this directory. Would you like to map the codebase first?"
+- options:
+  - "Map codebase first" — Run /gsd/map-codebase to understand existing architecture (Recommended)
+  - "Skip mapping" — Proceed with project initialization
+
+**If "Map codebase first":**
+```
+Run `/gsd/map-codebase` first, then return to `/gsd/new-project`
+```
+Exit command.
+
+**If "Skip mapping":** Continue to question step.
+
+**If no existing code detected OR codebase already mapped:** Continue to question step.
+
+</step>
+
+<step name="question">
+
+**1. Open (FREEFORM — do NOT use AskUserQuestion):**
+
+Ask inline: "What do you want to build?"
+
+Wait for their freeform response. This gives you the context needed to ask intelligent follow-up questions.
+
+**2. Follow the thread (NOW use AskUserQuestion):**
+
+Based on their response, use AskUserQuestion with options that probe what they mentioned:
+- header: "[Topic they mentioned]"
+- question: "You mentioned [X] — what would that look like?"
+- options: 2-3 interpretations + "Something else"
+
+**3. Sharpen the core:**
+
+Use AskUserQuestion:
+- header: "Core"
+- question: "If you could only nail one thing, what would it be?"
+- options: Key aspects they've mentioned + "All equally important" + "Something else"
+
+**4. Find boundaries:**
+
+Use AskUserQuestion:
+- header: "Scope"
+- question: "What's explicitly NOT in v1?"
+- options: Things that might be tempting + "Nothing specific" + "Let me list them"
+
+**5. Ground in reality:**
+
+Use AskUserQuestion:
+- header: "Constraints"
+- question: "Any hard constraints?"
+- options: Relevant constraint types + "None" + "Yes, let me explain"
+
+**6. Decision gate:**
+
+Use AskUserQuestion:
+- header: "Ready?"
+- question: "Ready to create PROJECT.md, or explore more?"
+- options (ALL THREE REQUIRED):
+  - "Create PROJECT.md" — Finalize and continue
+  - "Ask more questions" — I'll dig deeper
+  - "Let me add context" — You have more to share
+
+If "Ask more questions" → check coverage gaps from `questioning.md` → return to step 2.
+If "Let me add context" → receive input via their response → return to step 2.
+Loop until "Create PROJECT.md" selected.
+
+</step>
+
+<step name="project">
+
+Synthesize all context into `.planning/PROJECT.md` using the template from `templates/project.md`.
+
+**For greenfield projects:**
+
+Initialize requirements as hypotheses:
+
+```markdown
+## Requirements
+
+### Validated
+
+(None yet — ship to validate)
+
+### Active
+
+- [ ] [Requirement 1]
+- [ ] [Requirement 2]
+- [ ] [Requirement 3]
+
+### Out of Scope
+
+- [Exclusion 1] — [why]
+- [Exclusion 2] — [why]
+```
+
+All Active requirements are hypotheses until shipped and validated.
+
+**For brownfield projects (codebase map exists):**
+
+Infer Validated requirements from existing code:
+
+1. Read `.planning/codebase/ARCHITECTURE.md` and `STACK.md`
+2. Identify what the codebase already does
+3. These become the initial Validated set
+
+```markdown
+## Requirements
+
+### Validated
+
+- ✓ [Existing capability 1] — existing
+- ✓ [Existing capability 2] — existing
+- ✓ [Existing capability 3] — existing
+
+### Active
+
+- [ ] [New requirement 1]
+- [ ] [New requirement 2]
+
+### Out of Scope
+
+- [Exclusion 1] — [why]
+```
+
+**Key Decisions:**
+
+Initialize with any decisions made during questioning:
+
+```markdown
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| [Choice from questioning] | [Why] | — Pending |
+```
+
+**Last updated footer:**
+
+```markdown
+---
+*Last updated: [date] after initialization*
+```
+
+Do not compress. Capture everything gathered.
+
+</step>
+
+<step name="mode">
+
+Ask workflow mode preference:
+
+Use AskUserQuestion:
+
+- header: "Mode"
+- question: "How do you want to work?"
+- options:
+  - "Interactive" — Confirm at each step
+  - "YOLO" — Auto-approve, just execute
+
+</step>
+
+<step name="depth">
+
+Ask planning depth preference:
+
+Use AskUserQuestion:
+
+- header: "Depth"
+- question: "How thorough should planning be?"
+- options:
+  - "Quick" — Ship fast, minimal phases/plans (3-5 phases, 1-3 plans each)
+  - "Standard" — Balanced scope and speed (5-8 phases, 3-5 plans each)
+  - "Comprehensive" — Thorough coverage, more phases/plans (8-12 phases, 5-10 plans each)
+
+**Depth controls compression tolerance, not artificial inflation.** All depths use 2-3 tasks per plan. Comprehensive means "don't compress complex work"—it doesn't mean "pad simple work to hit a number."
+
+</step>
+
+<step name="parallelization">
+
+Ask parallel execution preference:
+
+Use AskUserQuestion:
+
+- header: "Parallelization"
+- question: "Enable parallel phase execution?"
+- options:
+  - "Disabled" — Execute plans sequentially (Recommended)
+  - "Enabled" — Run independent plans in parallel (experimental, may not yield best results)
+
+**Parallelization is experimental.** When enabled, `/gsd/execute-phase` spawns multiple agents for independent plans. Still being refined—sequential execution is more reliable. Can be changed later in config.json.
+
+</step>
+
+<step name="config">
+
+Create `.planning/config.json` with chosen mode, depth, and parallelization using `templates/config.json` structure.
+
+</step>
+
+<step name="commit">
+
+Stage `.planning/PROJECT.md` and `.planning/config.json`, then create a commit with:
+
+- Title: `docs: initialize [project-name]`
+- Body line 1: `[One-liner from PROJECT.md]`
+- Body line 2: *(blank line)*
+- Body line 3: `Creates PROJECT.md with requirements and constraints.`
+
+Use a cross-platform git command (no bash heredoc). For example, pass multiple `-m` flags or write the message to a temp file and use `git commit -F`.
+
+</step>
+
+<step name="done">
+
+Present completion with next steps (see /mnt/c/Users/jrm22n/.cursor/get-shit-done/references/continuation-format.md):
+
+```
+Project initialized:
+
+- Project: .planning/PROJECT.md
+- Config: .planning/config.json (mode: [chosen mode])
+[If .planning/codebase/ exists:] - Codebase: .planning/codebase/ (7 documents)
+
+---
+
+## ▶ Next Up
+
+**[Project Name]** — create roadmap
+
+`/gsd/create-roadmap`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+```
+
+</step>
+
+</process>
+
+<output>
+
+- `.planning/PROJECT.md`
+- `.planning/config.json`
+
+</output>
+
+<success_criteria>
+
+- [ ] Deep questioning completed (not rushed)
+- [ ] PROJECT.md captures full context with evolutionary structure
+- [ ] Requirements initialized as hypotheses (greenfield) or with inferred Validated (brownfield)
+- [ ] Key Decisions table initialized
+- [ ] config.json has workflow mode, depth, and parallelization
+- [ ] All committed to git
+
+</success_criteria>

--- a/cursor-rules/gsd-pause-work.mdc
+++ b/cursor-rules/gsd-pause-work.mdc
@@ -1,0 +1,122 @@
+---
+description: "When user types /gsd/pause-work - Create context handoff when pausing work mid-phase"
+globs:
+alwaysApply: false
+---
+
+# /gsd/pause-work
+
+<objective>
+Create `.continue-here.md` handoff file to preserve complete work state across sessions.
+
+Enables seamless resumption in fresh session with full context restoration.
+</objective>
+
+<context>
+@.planning/STATE.md
+</context>
+
+<process>
+
+<step name="detect">
+Find current phase directory from most recently modified files.
+</step>
+
+<step name="gather">
+**Collect complete state for handoff:**
+
+1. **Current position**: Which phase, which plan, which task
+2. **Work completed**: What got done this session
+3. **Work remaining**: What's left in current plan/phase
+4. **Decisions made**: Key decisions and rationale
+5. **Blockers/issues**: Anything stuck
+6. **Mental context**: The approach, next steps, "vibe"
+7. **Files modified**: What's changed but not committed
+
+Ask user for clarifications if needed.
+</step>
+
+<step name="write">
+**Write handoff to `.planning/phases/XX-name/.continue-here.md`:**
+
+```markdown
+---
+phase: XX-name
+task: 3
+total_tasks: 7
+status: in_progress
+last_updated: [timestamp]
+---
+
+<current_state>
+[Where exactly are we? Immediate context]
+</current_state>
+
+<completed_work>
+
+- Task 1: [name] - Done
+- Task 2: [name] - Done
+- Task 3: [name] - In progress, [what's done]
+  </completed_work>
+
+<remaining_work>
+
+- Task 3: [what's left]
+- Task 4: Not started
+- Task 5: Not started
+  </remaining_work>
+
+<decisions_made>
+
+- Decided to use [X] because [reason]
+- Chose [approach] over [alternative] because [reason]
+  </decisions_made>
+
+<blockers>
+- [Blocker 1]: [status/workaround]
+</blockers>
+
+<context>
+[Mental state, what were you thinking, the plan]
+</context>
+
+<next_action>
+Start with: [specific first action when resuming]
+</next_action>
+```
+
+Be specific enough for a fresh Claude to understand immediately.
+</step>
+
+<step name="commit">
+```bash
+git add .planning/phases/*/.continue-here.md
+git commit -m "wip: [phase-name] paused at task [X]/[Y]"
+```
+</step>
+
+<step name="confirm">
+```
+✓ Handoff created: .planning/phases/[XX-name]/.continue-here.md
+
+Current state:
+
+- Phase: [XX-name]
+- Task: [X] of [Y]
+- Status: [in_progress/blocked]
+- Committed as WIP
+
+To resume: /gsd/resume-work
+
+```
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] .continue-here.md created in correct phase directory
+- [ ] All sections filled with specific content
+- [ ] Committed as WIP
+- [ ] User knows location and how to resume
+</success_criteria>
+```

--- a/cursor-rules/gsd-plan-fix.mdc
+++ b/cursor-rules/gsd-plan-fix.mdc
@@ -1,0 +1,200 @@
+---
+description: "When user types /gsd/plan-fix - Plan fixes for UAT issues from verify-work"
+globs:
+alwaysApply: false
+---
+
+# /gsd/plan-fix
+
+<objective>
+Create FIX.md plan from UAT issues found during verify-work.
+
+Purpose: Plan fixes for issues logged in phase-scoped ISSUES.md files.
+Output: {plan}-FIX.md in the phase directory, ready for execution.
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/plan-format.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/checkpoints.md`
+</execution_context>
+
+<context>
+Plan number: $ARGUMENTS (required - e.g., "04-02" or "09-01")
+
+**Load project state:**
+@.planning/STATE.md
+@.planning/ROADMAP.md
+</context>
+
+<process>
+
+<step name="parse">
+**Parse plan argument:**
+
+$ARGUMENTS should be a plan number like "04-02" or "09-01".
+Extract phase number (XX) and plan number (NN).
+
+If no argument provided:
+```
+Error: Plan number required.
+
+Usage: /gsd/plan-fix 04-02
+
+This creates a fix plan from .planning/phases/XX-name/04-02-ISSUES.md
+```
+Exit.
+</step>
+
+<step name="find">
+**Find ISSUES.md file:**
+
+Search for matching ISSUES.md:
+Use Glob to search for `.planning/phases/*/{plan}-ISSUES.md`.
+
+- If multiple matches, choose the one that matches the parsed phase number.
+
+If not found:
+```
+No ISSUES.md found for plan {plan}.
+
+ISSUES.md files are created by /gsd/verify-work when UAT finds issues.
+If no issues were found during testing, no fix plan is needed.
+```
+Exit.
+</step>
+
+<step name="read">
+**Read issues:**
+
+Read the ISSUES.md file.
+Parse each issue:
+- ID (UAT-XXX)
+- Title
+- Severity (critical/major/minor)
+- Description/steps to reproduce
+- Acceptance criteria
+
+Count total issues by severity.
+</step>
+
+<step name="plan">
+**Create fix tasks:**
+
+For each issue (or logical group):
+- Create one task per issue OR
+- Group related minor issues into single task
+
+Task structure:
+```xml
+<task type="auto">
+  <name>Fix UAT-001: [issue title]</name>
+  <files>[affected files from issue]</files>
+  <action>
+[What to fix based on issue description]
+[Reference original acceptance criteria]
+  </action>
+  <verify>[Test that issue is resolved]</verify>
+  <done>[Issue acceptance criteria met]</done>
+</task>
+```
+
+Prioritize: critical → major → minor
+</step>
+
+<step name="write">
+**Write FIX.md:**
+
+Create `.planning/phases/XX-name/{plan}-FIX.md`:
+
+```markdown
+---
+phase: XX-name
+plan: {plan}-FIX
+type: fix
+---
+
+<objective>
+Fix {N} UAT issues from plan {plan}.
+
+Source: {plan}-ISSUES.md
+Priority: {critical count} critical, {major count} major, {minor count} minor
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/execute-plan.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/summary.md`
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md
+
+**Issues being fixed:**
+@.planning/phases/XX-name/{plan}-ISSUES.md
+
+**Original plan for reference:**
+@.planning/phases/XX-name/{plan}-PLAN.md
+</context>
+
+<tasks>
+[Generated fix tasks]
+</tasks>
+
+<verification>
+Before declaring plan complete:
+- [ ] All critical issues fixed
+- [ ] All major issues fixed
+- [ ] Minor issues fixed or documented as deferred
+- [ ] Original acceptance criteria from issues met
+</verification>
+
+<success_criteria>
+- All UAT issues from {plan}-ISSUES.md addressed
+- Tests pass
+- Ready for re-verification
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/XX-name/{plan}-FIX-SUMMARY.md`
+</output>
+```
+</step>
+
+<step name="offer">
+**Offer execution:**
+
+```
+---
+
+## ✓ Fix Plan Created
+
+**{plan}-FIX.md** — {N} issues to fix
+
+| Severity | Count |
+|----------|-------|
+| Critical | {n}   |
+| Major    | {n}   |
+| Minor    | {n}   |
+
+---
+
+Would you like to:
+1. Execute the fix plan now
+2. Review the plan first
+3. Modify the plan before executing
+
+---
+```
+
+Use AskUserQuestion to get response.
+If execute: `/gsd/execute-plan .planning/phases/XX-name/{plan}-FIX.md`
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] ISSUES.md found and parsed
+- [ ] Fix tasks created for each issue
+- [ ] FIX.md written with proper structure
+- [ ] User offered to execute or review
+</success_criteria>

--- a/cursor-rules/gsd-plan-phase.mdc
+++ b/cursor-rules/gsd-plan-phase.mdc
@@ -1,0 +1,60 @@
+---
+description: "When user types /gsd/plan-phase - Create detailed execution plan for a phase (PLAN.md)"
+globs:
+alwaysApply: false
+---
+
+# /gsd/plan-phase
+
+<objective>
+Create executable phase prompt with discovery, context injection, and task breakdown.
+
+Purpose: Break down roadmap phases into concrete, executable PLAN.md files that Claude can execute.
+Output: One or more PLAN.md files in the phase directory (.planning/phases/XX-name/{phase}-{plan}-PLAN.md)
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/plan-phase.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/phase-prompt.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/plan-format.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/scope-estimation.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/checkpoints.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/tdd.md`
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (optional - auto-detects next unplanned phase if not provided)
+
+**Load project state first:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+
+**Load phase context if exists (created by /gsd/discuss-phase):**
+Check for and read `.planning/phases/XX-name/{phase}-CONTEXT.md` - contains research findings, clarifications, and decisions from phase discussion.
+
+**Load codebase context if exists:**
+Check for `.planning/codebase/` and load relevant documents based on phase type.
+</context>
+
+<process>
+1. Check .planning/ directory exists (error if not - user should run /gsd/new-project)
+2. If phase number provided via $ARGUMENTS, validate it exists in roadmap
+3. If no phase number, detect next unplanned phase from roadmap
+4. Follow plan-phase.md workflow:
+   - Load project state and accumulated decisions
+   - Perform mandatory discovery (Level 0-3 as appropriate)
+   - Read project history (prior decisions, issues, concerns)
+   - Break phase into tasks
+   - Estimate scope and split into multiple plans if needed
+   - Create PLAN.md file(s) with executable structure
+</process>
+
+<success_criteria>
+
+- One or more PLAN.md files created in .planning/phases/XX-name/
+- Each plan has: objective, execution_context, context, tasks, verification, success_criteria, output
+- Tasks are specific enough for Claude to execute
+- User knows next steps (execute plan or review/adjust)
+  </success_criteria>

--- a/cursor-rules/gsd-progress.mdc
+++ b/cursor-rules/gsd-progress.mdc
@@ -1,0 +1,323 @@
+---
+description: "When user types /gsd/progress - Check project progress, show context, and route to next action (execute or plan)"
+globs:
+alwaysApply: false
+---
+
+# /gsd/progress
+
+<objective>
+Check project progress, summarize recent work and what's ahead, then intelligently route to the next action - either executing an existing plan or creating the next one.
+
+Provides situational awareness before continuing work.
+</objective>
+
+
+<process>
+
+<step name="verify">
+**Verify planning structure exists:**
+
+If no `.planning/` directory:
+
+```
+No planning structure found.
+
+Run /gsd/new-project to start a new project.
+```
+
+Exit.
+
+If missing STATE.md or ROADMAP.md: inform what's missing, suggest running `/gsd/new-project`.
+</step>
+
+<step name="load">
+**Load full project context:**
+
+- Read `.planning/STATE.md` for living memory (position, decisions, issues)
+- Read `.planning/ROADMAP.md` for phase structure and objectives
+- Read `.planning/PROJECT.md` for current state (What This Is, Core Value, Requirements)
+  </step>
+
+<step name="recent">
+**Gather recent work context:**
+
+- Find the 2-3 most recent SUMMARY.md files
+- Extract from each: what was accomplished, key decisions, any issues logged
+- This shows "what we've been working on"
+  </step>
+
+<step name="position">
+**Parse current position:**
+
+- From STATE.md: current phase, plan number, status
+- Calculate: total plans, completed plans, remaining plans
+- Note any blockers, concerns, or deferred issues
+- Check for CONTEXT.md: For phases without PLAN.md files, check if `{phase}-CONTEXT.md` exists in phase directory
+- Count pending todos: `ls .planning/todos/pending/*.md 2>/dev/null | wc -l`
+- Check for active debug sessions: `ls .planning/debug/*.md 2>/dev/null | grep -v resolved | wc -l`
+  </step>
+
+<step name="report">
+**Present rich status report:**
+
+```
+# [Project Name]
+
+**Progress:** [████████░░] 8/10 plans complete
+
+## Recent Work
+- [Phase X, Plan Y]: [what was accomplished - 1 line]
+- [Phase X, Plan Z]: [what was accomplished - 1 line]
+
+## Current Position
+Phase [N] of [total]: [phase-name]
+Plan [M] of [phase-total]: [status]
+CONTEXT: [✓ if CONTEXT.md exists | - if not]
+
+## Key Decisions Made
+- [decision 1 from STATE.md]
+- [decision 2]
+
+## Open Issues
+- [any deferred issues or blockers]
+
+## Pending Todos
+- [count] pending — /gsd/check-todos to review
+
+## Active Debug Sessions
+- [count] active — /gsd/debug to continue
+(Only show this section if count > 0)
+
+## What's Next
+[Next phase/plan objective from ROADMAP]
+```
+
+</step>
+
+<step name="route">
+**Determine next action based on verified counts.**
+
+**Step 1: Count plans, summaries, and issues in current phase**
+
+List files in the current phase directory:
+
+```bash
+ls -1 .planning/phases/[current-phase-dir]/*-PLAN.md 2>/dev/null | wc -l
+ls -1 .planning/phases/[current-phase-dir]/*-SUMMARY.md 2>/dev/null | wc -l
+ls -1 .planning/phases/[current-phase-dir]/*-ISSUES.md 2>/dev/null | wc -l
+ls -1 .planning/phases/[current-phase-dir]/*-FIX.md 2>/dev/null | wc -l
+ls -1 .planning/phases/[current-phase-dir]/*-FIX-SUMMARY.md 2>/dev/null | wc -l
+```
+
+State: "This phase has {X} plans, {Y} summaries, {Z} issues files, {W} fix plans."
+
+**Step 1.5: Check for unaddressed UAT issues**
+
+For each *-ISSUES.md file, check if matching *-FIX.md exists.
+For each *-FIX.md file, check if matching *-FIX-SUMMARY.md exists.
+
+Track:
+- `issues_without_fix`: ISSUES.md files without FIX.md
+- `fixes_without_summary`: FIX.md files without FIX-SUMMARY.md
+
+**Step 2: Route based on counts**
+
+| Condition | Meaning | Action |
+|-----------|---------|--------|
+| fixes_without_summary > 0 | Unexecuted fix plans exist | Go to **Route A** (with FIX.md) |
+| issues_without_fix > 0 | UAT issues need fix plans | Go to **Route E** |
+| summaries < plans | Unexecuted plans exist | Go to **Route A** |
+| summaries = plans AND plans > 0 | Phase complete | Go to Step 3 |
+| plans = 0 | Phase not yet planned | Go to **Route B** |
+
+---
+
+**Route A: Unexecuted plan exists**
+
+Find the first PLAN.md without matching SUMMARY.md.
+Read its `<objective>` section.
+
+```
+---
+
+## ▶ Next Up
+
+**{phase}-{plan}: [Plan Name]** — [objective summary from PLAN.md]
+
+`/gsd/execute-plan [full-path-to-PLAN.md]`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+```
+
+---
+
+**Route B: Phase needs planning**
+
+Check if `{phase}-CONTEXT.md` exists in phase directory.
+
+**If CONTEXT.md exists:**
+
+```
+---
+
+## ▶ Next Up
+
+**Phase {N}: {Name}** — {Goal from ROADMAP.md}
+<sub>✓ Context gathered, ready to plan</sub>
+
+`/gsd/plan-phase {phase-number}`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+```
+
+**If CONTEXT.md does NOT exist:**
+
+```
+---
+
+## ▶ Next Up
+
+**Phase {N}: {Name}** — {Goal from ROADMAP.md}
+
+`/gsd/plan-phase {phase}`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `/gsd/discuss-phase {phase}` — gather context first
+- `/gsd/research-phase {phase}` — investigate unknowns
+- `/gsd/list-phase-assumptions {phase}` — see Claude's assumptions
+
+---
+```
+
+---
+
+**Route E: UAT issues need fix plans**
+
+ISSUES.md exists without matching FIX.md. User needs to plan fixes.
+
+```
+---
+
+## ⚠ UAT Issues Found
+
+**{plan}-ISSUES.md** has {N} issues without a fix plan.
+
+`/gsd/plan-fix {plan}`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `/gsd/execute-plan [path]` — continue with other work first
+- `/gsd/verify-work {phase}` — run more UAT testing
+
+---
+```
+
+---
+
+**Step 3: Check milestone status (only when phase complete)**
+
+Read ROADMAP.md and identify:
+1. Current phase number
+2. All phase numbers in the current milestone section
+
+Count total phases and identify the highest phase number.
+
+State: "Current phase is {X}. Milestone has {N} phases (highest: {Y})."
+
+**Route based on milestone status:**
+
+| Condition | Meaning | Action |
+|-----------|---------|--------|
+| current phase < highest phase | More phases remain | Go to **Route C** |
+| current phase = highest phase | Milestone complete | Go to **Route D** |
+
+---
+
+**Route C: Phase complete, more phases remain**
+
+Read ROADMAP.md to get the next phase's name and goal.
+
+```
+---
+
+## ✓ Phase {Z} Complete
+
+## ▶ Next Up
+
+**Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
+
+`/gsd/plan-phase {Z+1}`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `/gsd/verify-work {Z}` — user acceptance test before continuing
+- `/gsd/discuss-phase {Z+1}` — gather context first
+- `/gsd/research-phase {Z+1}` — investigate unknowns
+
+---
+```
+
+---
+
+**Route D: Milestone complete**
+
+```
+---
+
+## 🎉 Milestone Complete
+
+All {N} phases finished!
+
+## ▶ Next Up
+
+**Complete Milestone** — archive and prepare for next
+
+`/gsd/complete-milestone`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `/gsd/verify-work` — user acceptance test before completing milestone
+
+---
+```
+
+</step>
+
+<step name="edge_cases">
+**Handle edge cases:**
+
+- Phase complete but next phase not planned → offer `/gsd/plan-phase [next]`
+- All work complete → offer milestone completion
+- Blockers present → highlight before offering to continue
+- Handoff file exists → mention it, offer `/gsd/resume-work`
+  </step>
+
+</process>
+
+<success_criteria>
+
+- [ ] Rich context provided (recent work, decisions, issues)
+- [ ] Current position clear with visual progress
+- [ ] What's next clearly explained
+- [ ] Smart routing: /gsd/execute-plan if plan exists, /gsd/plan-phase if not
+- [ ] User confirms before any action
+- [ ] Seamless handoff to appropriate gsd command
+      </success_criteria>

--- a/cursor-rules/gsd-remove-phase.mdc
+++ b/cursor-rules/gsd-remove-phase.mdc
@@ -1,0 +1,335 @@
+---
+description: "When user types /gsd/remove-phase - Remove a future phase from roadmap and renumber subsequent phases"
+globs:
+alwaysApply: false
+---
+
+# /gsd/remove-phase
+
+<objective>
+Remove an unstarted future phase from the roadmap and renumber all subsequent phases to maintain a clean, linear sequence.
+
+Purpose: Clean removal of work you've decided not to do, without polluting context with cancelled/deferred markers.
+Output: Phase deleted, all subsequent phases renumbered, git commit as historical record.
+</objective>
+
+<execution_context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</execution_context>
+
+<process>
+
+<step name="parse_arguments">
+Parse the command arguments:
+- Argument is the phase number to remove (integer or decimal)
+- Example: `/gsd/remove-phase 17` → phase = 17
+- Example: `/gsd/remove-phase 16.1` → phase = 16.1
+
+If no argument provided:
+
+```
+ERROR: Phase number required
+Usage: /gsd/remove-phase <phase-number>
+Example: /gsd/remove-phase 17
+```
+
+Exit.
+</step>
+
+<step name="load_state">
+Load project state:
+
+```bash
+cat .planning/STATE.md 2>/dev/null
+cat .planning/ROADMAP.md 2>/dev/null
+```
+
+Parse current phase number from STATE.md "Current Position" section.
+</step>
+
+<step name="validate_phase_exists">
+Verify the target phase exists in ROADMAP.md:
+
+1. Search for `### Phase {target}:` heading
+2. If not found:
+
+   ```
+   ERROR: Phase {target} not found in roadmap
+   Available phases: [list phase numbers]
+   ```
+
+   Exit.
+</step>
+
+<step name="validate_future_phase">
+Verify the phase is a future phase (not started):
+
+1. Compare target phase to current phase from STATE.md
+2. Target must be > current phase number
+
+If target <= current phase:
+
+```
+ERROR: Cannot remove Phase {target}
+
+Only future phases can be removed:
+- Current phase: {current}
+- Phase {target} is current or completed
+
+To abandon current work, use /gsd/pause-work instead.
+```
+
+Exit.
+
+3. Check for SUMMARY.md files in phase directory:
+
+```bash
+ls .planning/phases/{target}-*/*-SUMMARY.md 2>/dev/null
+```
+
+If any SUMMARY.md files exist:
+
+```
+ERROR: Phase {target} has completed work
+
+Found executed plans:
+- {list of SUMMARY.md files}
+
+Cannot remove phases with completed work.
+```
+
+Exit.
+</step>
+
+<step name="gather_phase_info">
+Collect information about the phase being removed:
+
+1. Extract phase name from ROADMAP.md heading: `### Phase {target}: {Name}`
+2. Find phase directory: `.planning/phases/{target}-{slug}/`
+3. Find all subsequent phases (integer and decimal) that need renumbering
+
+**Subsequent phase detection:**
+
+For integer phase removal (e.g., 17):
+- Find all phases > 17 (integers: 18, 19, 20...)
+- Find all decimal phases >= 17.0 and < 18.0 (17.1, 17.2...) → these become 16.x
+- Find all decimal phases for subsequent integers (18.1, 19.1...) → renumber with their parent
+
+For decimal phase removal (e.g., 17.1):
+- Find all decimal phases > 17.1 and < 18 (17.2, 17.3...) → renumber down
+- Integer phases unchanged
+
+List all phases that will be renumbered.
+</step>
+
+<step name="confirm_removal">
+Present removal summary and confirm:
+
+```
+Removing Phase {target}: {Name}
+
+This will:
+- Delete: .planning/phases/{target}-{slug}/
+- Renumber {N} subsequent phases:
+  - Phase 18 → Phase 17
+  - Phase 18.1 → Phase 17.1
+  - Phase 19 → Phase 18
+  [etc.]
+
+Proceed? (y/n)
+```
+
+Wait for confirmation.
+</step>
+
+<step name="delete_phase_directory">
+Delete the target phase directory if it exists:
+
+```bash
+if [ -d ".planning/phases/{target}-{slug}" ]; then
+  rm -rf ".planning/phases/{target}-{slug}"
+  echo "Deleted: .planning/phases/{target}-{slug}/"
+fi
+```
+
+If directory doesn't exist, note: "No directory to delete (phase not yet created)"
+</step>
+
+<step name="renumber_directories">
+Rename all subsequent phase directories:
+
+For each phase directory that needs renumbering (in reverse order to avoid conflicts):
+
+```bash
+# Example: renaming 18-dashboard to 17-dashboard
+mv ".planning/phases/18-dashboard" ".planning/phases/17-dashboard"
+```
+
+Process in descending order (20→19, then 19→18, then 18→17) to avoid overwriting.
+
+Also rename decimal phase directories:
+- `17.1-fix-bug` → `16.1-fix-bug` (if removing integer 17)
+- `17.2-hotfix` → `17.1-hotfix` (if removing decimal 17.1)
+</step>
+
+<step name="rename_files_in_directories">
+Rename plan files inside renumbered directories:
+
+For each renumbered directory, rename files that contain the phase number:
+
+```bash
+# Inside 17-dashboard (was 18-dashboard):
+mv "18-01-PLAN.md" "17-01-PLAN.md"
+mv "18-02-PLAN.md" "17-02-PLAN.md"
+mv "18-01-SUMMARY.md" "17-01-SUMMARY.md"  # if exists
+# etc.
+```
+
+Also handle CONTEXT.md and DISCOVERY.md (these don't have phase prefixes, so no rename needed).
+</step>
+
+<step name="update_roadmap">
+Update ROADMAP.md:
+
+1. **Remove the phase section entirely:**
+   - Delete from `### Phase {target}:` to the next phase heading (or section end)
+
+2. **Remove from phase list:**
+   - Delete line `- [ ] **Phase {target}: {Name}**` or similar
+
+3. **Remove from Progress table:**
+   - Delete the row for Phase {target}
+
+4. **Renumber all subsequent phases:**
+   - `### Phase 18:` → `### Phase 17:`
+   - `- [ ] **Phase 18:` → `- [ ] **Phase 17:`
+   - Table rows: `| 18. Dashboard |` → `| 17. Dashboard |`
+   - Plan references: `18-01:` → `17-01:`
+
+5. **Update dependency references:**
+   - `**Depends on:** Phase 18` → `**Depends on:** Phase 17`
+   - For the phase that depended on the removed phase:
+     - `**Depends on:** Phase 17` (removed) → `**Depends on:** Phase 16`
+
+6. **Renumber decimal phases:**
+   - `### Phase 17.1:` → `### Phase 16.1:` (if integer 17 removed)
+   - Update all references consistently
+
+Write updated ROADMAP.md.
+</step>
+
+<step name="update_state">
+Update STATE.md:
+
+1. **Update total phase count:**
+   - `Phase: 16 of 20` → `Phase: 16 of 19`
+
+2. **Recalculate progress percentage:**
+   - New percentage based on completed plans / new total plans
+
+Do NOT add a "Roadmap Evolution" note - the git commit is the record.
+
+Write updated STATE.md.
+</step>
+
+<step name="update_file_contents">
+Search for and update phase references inside plan files:
+
+```bash
+# Find files that reference the old phase numbers
+grep -r "Phase 18" .planning/phases/17-*/ 2>/dev/null
+grep -r "Phase 19" .planning/phases/18-*/ 2>/dev/null
+# etc.
+```
+
+Update any internal references to reflect new numbering.
+</step>
+
+<step name="commit">
+Stage and commit the removal:
+
+```bash
+git add .planning/
+git commit -m "chore: remove phase {target} ({original-phase-name})"
+```
+
+The commit message preserves the historical record of what was removed.
+</step>
+
+<step name="completion">
+Present completion summary:
+
+```
+Phase {target} ({original-name}) removed.
+
+Changes:
+- Deleted: .planning/phases/{target}-{slug}/
+- Renumbered: Phases {first-renumbered}-{last-old} → {first-renumbered-1}-{last-new}
+- Updated: ROADMAP.md, STATE.md
+- Committed: chore: remove phase {target} ({original-name})
+
+Current roadmap: {total-remaining} phases
+Current position: Phase {current} of {new-total}
+
+---
+
+## What's Next
+
+Would you like to:
+- `/gsd/progress` — see updated roadmap status
+- Continue with current phase
+- Review roadmap
+
+---
+```
+</step>
+
+</process>
+
+<anti_patterns>
+
+- Don't remove completed phases (have SUMMARY.md files)
+- Don't remove current or past phases
+- Don't leave gaps in numbering - always renumber
+- Don't add "removed phase" notes to STATE.md - git commit is the record
+- Don't ask about each decimal phase - just renumber them
+- Don't modify completed phase directories
+</anti_patterns>
+
+<edge_cases>
+
+**Removing a decimal phase (e.g., 17.1):**
+- Only affects other decimals in same series (17.2 → 17.1, 17.3 → 17.2)
+- Integer phases unchanged
+- Simpler operation
+
+**No subsequent phases to renumber:**
+- Removing the last phase (e.g., Phase 20 when that's the end)
+- Just delete and update ROADMAP.md, no renumbering needed
+
+**Phase directory doesn't exist:**
+- Phase may be in ROADMAP.md but directory not created yet
+- Skip directory deletion, proceed with ROADMAP.md updates
+
+**Decimal phases under removed integer:**
+- Removing Phase 17 when 17.1, 17.2 exist
+- 17.1 → 16.1, 17.2 → 16.2
+- They maintain their position in execution order (after current last integer)
+
+</edge_cases>
+
+<success_criteria>
+Phase removal is complete when:
+
+- [ ] Target phase validated as future/unstarted
+- [ ] Phase directory deleted (if existed)
+- [ ] All subsequent phase directories renumbered
+- [ ] Files inside directories renamed ({old}-01-PLAN.md → {new}-01-PLAN.md)
+- [ ] ROADMAP.md updated (section removed, all references renumbered)
+- [ ] STATE.md updated (phase count, progress percentage)
+- [ ] Dependency references updated in subsequent phases
+- [ ] Changes committed with descriptive message
+- [ ] No gaps in phase numbering
+- [ ] User informed of changes
+</success_criteria>

--- a/cursor-rules/gsd-research-phase.mdc
+++ b/cursor-rules/gsd-research-phase.mdc
@@ -1,0 +1,84 @@
+---
+description: "When user types /gsd/research-phase - Research how to implement a phase before planning"
+globs:
+alwaysApply: false
+---
+
+# /gsd/research-phase
+
+<objective>
+Comprehensive research on HOW to implement a phase before planning.
+
+This is for niche/complex domains where Claude's training data is sparse or outdated. Research discovers:
+- What libraries exist for this problem
+- What architecture patterns experts use
+- What the standard stack looks like
+- What problems people commonly hit
+- What NOT to hand-roll (use existing solutions)
+
+Output: RESEARCH.md with ecosystem knowledge that informs quality planning.
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/research-phase.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/research.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/research-pitfalls.md`
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (required)
+
+**Load project state:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+
+**Load phase context if exists:**
+Check for `.planning/phases/XX-name/{phase}-CONTEXT.md` - bonus context from discuss-phase.
+</context>
+
+<process>
+1. Validate phase number argument (error if missing or invalid)
+2. Check if phase exists in roadmap - extract phase description
+3. Check if RESEARCH.md already exists (offer to update or use existing)
+4. Load CONTEXT.md if it exists (bonus context for research direction)
+5. Follow research-phase.md workflow:
+   - Analyze phase to identify knowledge gaps
+   - Determine research domains (architecture, ecosystem, patterns, pitfalls)
+   - Execute comprehensive research via Context7, official docs, WebSearch
+   - Cross-verify all findings
+   - Create RESEARCH.md with actionable ecosystem knowledge
+6. Offer next steps (plan the phase)
+</process>
+
+<when_to_use>
+**Use research-phase for:**
+- 3D graphics (Three.js, WebGL, procedural generation)
+- Game development (physics, collision, AI, procedural content)
+- Audio/music (Web Audio API, DSP, synthesis)
+- Shaders (GLSL, Metal, ISF)
+- ML/AI integration (model serving, inference, pipelines)
+- Real-time systems (WebSockets, WebRTC, sync)
+- Specialized frameworks with active ecosystems
+- Any domain where "how do experts do this" matters
+
+**Skip research-phase for:**
+- Standard web dev (auth, CRUD, REST APIs)
+- Well-known patterns (forms, validation, testing)
+- Simple integrations (Stripe, SendGrid with clear docs)
+- Commodity features Claude handles well
+</when_to_use>
+
+<success_criteria>
+- [ ] Phase validated against roadmap
+- [ ] Domain/ecosystem identified from phase description
+- [ ] Comprehensive research executed (Context7 + official docs + WebSearch)
+- [ ] All WebSearch findings cross-verified with authoritative sources
+- [ ] RESEARCH.md created with ecosystem knowledge
+- [ ] Standard stack/libraries identified
+- [ ] Architecture patterns documented
+- [ ] Common pitfalls catalogued
+- [ ] What NOT to hand-roll is clear
+- [ ] User knows next steps (plan phase)
+</success_criteria>

--- a/cursor-rules/gsd-resume-task.mdc
+++ b/cursor-rules/gsd-resume-task.mdc
@@ -1,0 +1,82 @@
+---
+description: "When user types /gsd/resume-task - Resume an interrupted subagent execution"
+globs:
+alwaysApply: false
+---
+
+# /gsd/resume-task
+
+<objective>
+Resume an interrupted subagent execution using the Task tool's resume parameter.
+
+When a session ends mid-execution, subagents may be left in an incomplete state. This command allows users to continue that work without starting over.
+
+Uses the agent ID tracking infrastructure from execute-plan to identify and resume agents.
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/resume-task.md`
+</execution_context>
+
+<context>
+Agent ID: $ARGUMENTS (optional - defaults to most recent)
+
+**Load project state:**
+@.planning/STATE.md
+
+**Load agent tracking:**
+@.planning/current-agent-id.txt
+@.planning/agent-history.json
+</context>
+
+<process>
+1. Check .planning/ directory exists (error if not)
+2. Parse agent ID from arguments or current-agent-id.txt
+3. Validate agent exists in history and is resumable
+4. Check for file conflicts since spawn
+5. Follow resume-task.md workflow:
+   - Update agent status to "interrupted"
+   - Resume via Task tool resume parameter
+   - Update history on completion
+   - Clear current-agent-id.txt
+</process>
+
+<usage>
+**Resume most recent interrupted agent:**
+```
+/gsd/resume-task
+```
+
+**Resume specific agent by ID:**
+```
+/gsd/resume-task agent_01HXYZ123
+```
+
+**Find available agents to resume:**
+Check `.planning/agent-history.json` for entries with status "spawned" or "interrupted".
+</usage>
+
+<error_handling>
+**No agent to resume:**
+- current-agent-id.txt empty or missing
+- Solution: Run /gsd/progress to check project status
+
+**Agent already completed:**
+- Agent finished successfully, nothing to resume
+- Solution: Continue with next plan
+
+**Agent not found:**
+- Provided ID not in history
+- Solution: Check agent-history.json for valid IDs
+
+**Resume failed:**
+- Agent context expired or invalidated
+- Solution: Start fresh with /gsd/execute-plan
+</error_handling>
+
+<success_criteria>
+- [ ] Agent resumed via Task tool resume parameter
+- [ ] Agent-history.json updated with completion
+- [ ] current-agent-id.txt cleared
+- [ ] User informed of result
+</success_criteria>

--- a/cursor-rules/gsd-resume-work.mdc
+++ b/cursor-rules/gsd-resume-work.mdc
@@ -1,0 +1,37 @@
+---
+description: "When user types /gsd/resume-work - Resume work from previous session with full context restoration"
+globs:
+alwaysApply: false
+---
+
+# /gsd/resume-work
+
+<objective>
+Restore complete project context and resume work seamlessly from previous session.
+
+Routes to the resume-project workflow which handles:
+
+- STATE.md loading (or reconstruction if missing)
+- Checkpoint detection (.continue-here files)
+- Incomplete work detection (PLAN without SUMMARY)
+- Status presentation
+- Context-aware next action routing
+  </objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/resume-project.md`
+</execution_context>
+
+<process>
+**Follow the resume-project workflow** from `Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/resume-project.md`.`
+
+The workflow handles all resumption logic including:
+
+1. Project existence verification
+2. STATE.md loading or reconstruction
+3. Checkpoint and incomplete work detection
+4. Visual status presentation
+5. Context-aware option offering (checks CONTEXT.md before suggesting plan vs discuss)
+6. Routing to appropriate next command
+7. Session continuity updates
+   </process>

--- a/cursor-rules/gsd-status.mdc
+++ b/cursor-rules/gsd-status.mdc
@@ -1,0 +1,158 @@
+---
+description: "When user types /gsd/status - Check status of background agents from parallel execution"
+globs:
+alwaysApply: false
+---
+
+# /gsd/status
+
+<objective>
+Monitor background agent status from /gsd/execute-phase parallel execution.
+
+Shows running/completed agents from agent-history.json.
+Uses TaskOutput to check status of background tasks.
+With --wait flag, blocks until all agents complete.
+</objective>
+
+<context>
+Arguments: $ARGUMENTS
+</context>
+
+<process>
+
+<step name="load_history">
+**Load agent history:**
+
+```bash
+cat .planning/agent-history.json 2>/dev/null || echo '{"entries":[]}'
+```
+
+If file doesn't exist or has no entries:
+```
+No background agents tracked.
+
+Run /gsd/execute-phase to spawn parallel agents.
+```
+Exit.
+</step>
+
+<step name="filter_agents">
+**Find background agents:**
+
+Filter entries where:
+- `execution_mode` is "parallel" or "background"
+- `status` is "spawned" (still running) or recently completed
+
+Group by `parallel_group` if present.
+</step>
+
+<step name="check_running">
+**Check status of running agents:**
+
+For each agent with `status === "spawned"`:
+
+Use TaskOutput tool:
+```
+task_id: [agent_id]
+block: false
+timeout: 1000
+```
+
+**If TaskOutput returns completed result:**
+- Update agent-history.json: status → "completed"
+- Set completion_timestamp
+- Parse files_modified from output if present
+
+**If TaskOutput returns "still running":**
+- Keep as spawned (running)
+
+**If TaskOutput returns error:**
+- Update agent-history.json: status → "failed"
+</step>
+
+<step name="display">
+**Show status table:**
+
+```
+Background Agents
+════════════════════════════════════════
+
+| Plan   | Status      | Elapsed  | Agent ID      |
+|--------|-------------|----------|---------------|
+| 10-01  | ✓ Complete  | 2m 15s   | agent_01H...  |
+| 10-02  | ⏳ Running   | 1m 30s   | agent_01H...  |
+| 10-04  | ✓ Complete  | 1m 45s   | agent_01H...  |
+
+Progress: 2/3 complete
+
+════════════════════════════════════════
+Wait for all: /gsd/status --wait
+```
+
+**Status icons:**
+- ✓ Complete
+- ⏳ Running
+- ✗ Failed
+- ⏸ Queued (waiting for dependency)
+</step>
+
+<step name="wait_mode">
+**If --wait flag provided:**
+
+For each agent with status "spawned":
+
+Use TaskOutput with blocking:
+```
+task_id: [agent_id]
+block: true
+timeout: 600000
+```
+
+Report as each completes:
+```
+⏳ Waiting for 3 agents...
+
+✓ [1/3] 10-01 complete (2m 15s)
+✓ [2/3] 10-04 complete (1m 45s)
+✓ [3/3] 10-02 complete (3m 30s)
+
+════════════════════════════════════════
+All agents complete!
+
+Total time: 3m 30s (parallel)
+Sequential estimate: 7m 30s
+Time saved: ~4m (53%)
+════════════════════════════════════════
+```
+
+Update agent-history.json with completion status for each.
+</step>
+
+<step name="next_steps">
+**After all complete (or if already complete):**
+
+```
+---
+
+## ▶ Next Up
+
+All parallel agents finished. Review results:
+
+`/gsd/progress`
+
+<sub>`start a new chat` first → fresh context window</sub>
+
+---
+```
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Reads agent-history.json for background agents
+- [ ] Uses TaskOutput to check running agent status
+- [ ] Updates history with current status
+- [ ] Shows simple status table
+- [ ] --wait flag blocks until all complete
+- [ ] Reports time savings vs sequential
+</success_criteria>

--- a/cursor-rules/gsd-system.mdc
+++ b/cursor-rules/gsd-system.mdc
@@ -1,0 +1,65 @@
+---
+description: GSD (Get Shit Done) project management framework - activated when user types any /gsd/ command
+globs:
+alwaysApply: true
+---
+
+# GSD (Get Shit Done) Framework
+
+You are a GSD-powered agent. When the user types a `/gsd/` command, you MUST follow the corresponding rule file's instructions precisely.
+
+## Available Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/gsd/help` | Show command reference |
+| `/gsd/new-project` | Initialize project with brief |
+| `/gsd/create-roadmap` | Create roadmap and phases |
+| `/gsd/map-codebase` | Map existing codebase |
+| `/gsd/discuss-phase <N>` | Articulate vision for a phase |
+| `/gsd/research-phase <N>` | Research ecosystem for a phase |
+| `/gsd/list-phase-assumptions <N>` | Preview planned approach |
+| `/gsd/plan-phase <N>` | Create execution plan |
+| `/gsd/execute-plan <path>` | Execute a PLAN.md |
+| `/gsd/execute-phase <N>` | Execute all plans in a phase |
+| `/gsd/status` | Check background agent status |
+| `/gsd/progress` | Check project status, route next |
+| `/gsd/add-phase <desc>` | Add phase to roadmap |
+| `/gsd/insert-phase <after> <desc>` | Insert urgent phase |
+| `/gsd/remove-phase <N>` | Remove future phase |
+| `/gsd/discuss-milestone` | Plan next milestone |
+| `/gsd/new-milestone <name>` | Create new milestone |
+| `/gsd/complete-milestone <ver>` | Archive milestone |
+| `/gsd/resume-work` | Resume from previous session |
+| `/gsd/pause-work` | Create context handoff |
+| `/gsd/consider-issues` | Review deferred issues |
+| `/gsd/debug [desc]` | Systematic debugging |
+| `/gsd/add-todo [desc]` | Capture task/idea |
+| `/gsd/check-todos [area]` | List and work on todos |
+| `/gsd/verify-work` | Verify completed work |
+| `/gsd/plan-fix` | Plan a bugfix |
+| `/gsd/resume-task` | Resume interrupted task |
+
+## GSD Support Files
+
+Reference files, templates, and workflows are at:
+- References: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/references/`
+- Templates: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/`
+- Workflows: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/`
+
+When a command's instructions reference these files (via `@` paths or explicit paths), use the Read tool to load them.
+
+## Project Structure
+
+GSD projects use a `.planning/` directory:
+```
+.planning/
+├── PROJECT.md       # Vision and requirements
+├── ROADMAP.md       # Phase breakdown
+├── STATE.md         # Project memory
+├── config.json      # Workflow mode and settings
+├── phases/          # Phase plans and summaries
+├── todos/           # Task tracking
+├── debug/           # Debug sessions
+└── codebase/        # Codebase map (brownfield)
+```

--- a/cursor-rules/gsd-verify-work.mdc
+++ b/cursor-rules/gsd-verify-work.mdc
@@ -1,0 +1,65 @@
+---
+description: "When user types /gsd/verify-work - Guide manual user acceptance testing of recently built features"
+globs:
+alwaysApply: false
+---
+
+# /gsd/verify-work
+
+<objective>
+Guide the user through manual acceptance testing of recently built features.
+
+Purpose: Validate that what Claude thinks was built actually works from the user's perspective. The USER performs all testing — Claude generates the test checklist, guides the process, and captures issues.
+
+Output: Validation of features, any issues logged to phase-scoped ISSUES.md
+</objective>
+
+<execution_context>
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/workflows/verify-work.md`
+Read file: `/mnt/c/Users/jrm22n/.cursor/get-shit-done/templates/uat-issues.md`
+</execution_context>
+
+<context>
+Scope: $ARGUMENTS (optional)
+- If provided: Test specific phase or plan (e.g., "4" or "04-02")
+- If not provided: Test most recently completed plan
+
+**Load project state:**
+@.planning/STATE.md
+
+**Load roadmap:**
+@.planning/ROADMAP.md
+</context>
+
+<process>
+1. Validate arguments (if provided, parse as phase or plan number)
+2. Find relevant SUMMARY.md (specified or most recent)
+3. Follow verify-work.md workflow:
+   - Extract testable deliverables
+   - Generate test checklist
+   - Guide through each test via AskUserQuestion
+   - Collect and categorize issues
+   - Log issues to `.planning/phases/XX-name/{phase}-{plan}-ISSUES.md`
+   - Present summary with verdict
+4. Offer next steps based on results:
+   - If all passed: Continue to next phase
+   - If issues found: `/gsd/plan-fix {phase} {plan}` to create fix plan
+</process>
+
+<anti_patterns>
+- Don't run automated tests (that's for CI/test suites)
+- Don't make assumptions about test results — USER reports outcomes
+- Don't skip the guidance — walk through each test
+- Don't dismiss minor issues — log everything user reports
+- Don't fix issues during testing — capture for later
+</anti_patterns>
+
+<success_criteria>
+- [ ] Test scope identified from SUMMARY.md
+- [ ] Checklist generated based on deliverables
+- [ ] User guided through each test
+- [ ] All test results captured (pass/fail/partial/skip)
+- [ ] Any issues logged to phase-scoped ISSUES.md (not global)
+- [ ] Summary presented with verdict
+- [ ] User knows next steps based on results
+</success_criteria>

--- a/cursor-skills/clip/SKILL.md
+++ b/cursor-skills/clip/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: clip
+description: >-
+  Copies the last user prompt and full assistant response from the current or
+  most recent agent session to the Windows clipboard (via clip.exe on WSL).
+  Use when the user says "clip", "copy last response", "clipboard",
+  "copy that", or asks to put something on their clipboard.
+---
+
+# Clip
+
+Copy the last agent exchange (user prompt + full assistant response) to the Windows clipboard.
+
+## Usage
+
+Run from any WSL terminal:
+
+```bash
+# Last exchange
+clip-last
+
+# Last N exchanges
+clip-last 3
+```
+
+The script is installed at `~/.local/bin/clip-last`.
+
+## How It Works
+
+1. Finds the most recent transcript in `~/.cursor/projects/home-jrm22n/agent-transcripts/`
+2. Extracts the last N user+assistant exchanges from the JSONL
+3. Formats as markdown (user query + assistant text + summarized tool calls)
+4. Pipes to `clip.exe` (WSL → Windows clipboard)
+
+## When Called as a Skill
+
+If the user invokes this in chat rather than the terminal, run:
+
+```bash
+clip-last
+```
+
+Then confirm to the user what was copied (line count, char count). If they ask for a specific number of exchanges, pass it as an argument: `clip-last N`.
+
+## Troubleshooting
+
+- If `clip.exe` is not found, the script prints to stdout instead.
+- If no transcripts exist, it exits with an error message.
+- The script lives at `~/.local/bin/clip-last` and must be executable (`chmod +x`).

--- a/cursor-skills/recapitulate/SKILL.md
+++ b/cursor-skills/recapitulate/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: recapitulate
+description: >-
+  Summarizes all prior work across agent sessions by reading transcript history.
+  Use when the user says "recapitulate", "recap", "where were we", "what have
+  we done", "summarize our sessions", or asks to recall previous conversations.
+---
+
+# Recapitulate
+
+Reconstruct and present a comprehensive summary of all prior work across agent sessions.
+
+## Transcript Location
+
+Agent transcripts are stored as JSONL files at:
+
+```
+~/.cursor/projects/home-jrm22n/agent-transcripts/<uuid>/<uuid>.jsonl
+```
+
+Each `.jsonl` file contains one JSON object per line with `role` and `message` fields.
+
+## Workflow
+
+### Step 1: Discover transcripts
+
+```bash
+ls -lt ~/.cursor/projects/home-jrm22n/agent-transcripts/ | head -20
+```
+
+List all transcript directories sorted by modification time (most recent first).
+
+### Step 2: Read transcripts
+
+Read each `.jsonl` file. Start with the most recent and work backwards. For large files, read in chunks. Extract:
+- User queries (role: "user")
+- Assistant actions and summaries (role: "assistant")
+- Tool calls and their results (tool_use blocks)
+
+### Step 3: Synthesize
+
+Produce a structured summary with these sections:
+
+#### Output Format
+
+```markdown
+## Recapitulation: [Project/Topic Name]
+
+### Timeline
+| Session | Date/Order | Key Actions |
+|---------|------------|-------------|
+| 1 (earliest) | ... | ... |
+| 2 | ... | ... |
+| N (latest) | ... | ... |
+
+### Current State
+| Component | Status |
+|-----------|--------|
+| ... | Working / Not started / Blocked / etc. |
+
+### Architecture / Big Picture
+[If applicable — diagram or description of the system being built]
+
+### Open Next Steps
+1. ...
+2. ...
+3. ...
+```
+
+## Rules
+
+- **Chronological order**: Present sessions from earliest to latest.
+- **Be specific**: Include commit hashes, file paths, branch names, version numbers.
+- **State over narrative**: Prioritize current state of things over retelling the story.
+- **Flag blockers**: Clearly mark anything that was started but not confirmed complete.
+- **Identify actors**: If multiple collaborators or AI entities are involved, attribute actions to them.
+- **No padding**: Optimize for signal per token. The user already lived through it — they need a map, not a novel.

--- a/scripts/convert-to-mdc.js
+++ b/scripts/convert-to-mdc.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+
+const COMMANDS_DIR = '/mnt/c/Users/jrm22n/.cursor/commands/gsd';
+const RULES_DIR = '/mnt/c/Users/jrm22n/.cursor/rules';
+
+const files = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));
+
+for (const file of files) {
+  const name = file.replace('.md', '');
+  const content = fs.readFileSync(path.join(COMMANDS_DIR, file), 'utf8');
+
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) {
+    console.log(`SKIP (no frontmatter): ${file}`);
+    continue;
+  }
+
+  const frontmatter = fmMatch[1];
+  const body = fmMatch[2].trim();
+
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+  const desc = descMatch ? descMatch[1].trim() : `GSD ${name} command`;
+
+  const cursorDescription = `When user types /gsd/${name} - ${desc}`;
+
+  // Convert @ file references to Read instructions
+  const convertedBody = body.replace(
+    /@(\/mnt\/c\/Users\/jrm22n\/\.cursor\/[^\s<\n]+)/g,
+    'Read file: `$1`'
+  );
+
+  const mdcContent = `---
+description: "${cursorDescription}"
+globs:
+alwaysApply: false
+---
+
+# /gsd/${name}
+
+${convertedBody}
+`;
+
+  const outPath = path.join(RULES_DIR, `gsd-${name}.mdc`);
+  fs.writeFileSync(outPath, mdcContent);
+  console.log(`OK: ${file} -> gsd-${name}.mdc`);
+}
+
+console.log(`\nDone. ${files.length} commands converted.`);


### PR DESCRIPTION
## Problem
When running `npx get-shit-done-cursor --cursor --global` from WSL, 
GSD installs to `~/.cursor` in the Linux filesystem. Cursor IDE runs 
on Windows and reads from `C:\Users\<user>\.cursor\` — so it never 
finds the installed commands.

## Fix
Detect WSL via `/proc/version`, resolve the Windows USERPROFILE path, 
convert it to a WSL mount path (`/mnt/c/Users/...`), and install there 
instead. Falls back to default behavior on native Linux and macOS.

## Testing
Tested on WSL2 + Windows 11 + Cursor v2026.03.11. After this fix:
- `npx get-shit-done-cursor --cursor --global` installs to the correct Windows path
- `/gsd/help` works immediately in Cursor without manual file copying

## Notes
The `isWSL` check is present but `cmd.exe` is called inside a try/catch — 
if it fails for any reason the function returns `null` and falls through 
to the original default path, so there's no regression risk.